### PR TITLE
Fix the DM worker tests so CI passes again

### DIFF
--- a/__tests__/dm-worker.test.ts
+++ b/__tests__/dm-worker.test.ts
@@ -17,6 +17,7 @@ const {
     },
     dmLog: {
       findUnique: vi.fn(),
+      create: vi.fn(),
       upsert: vi.fn(),
       update: vi.fn(),
     },
@@ -173,6 +174,7 @@ beforeEach(() => {
 
   mockPrisma.automation.findMany.mockResolvedValue([mockAutomation]);
   mockPrisma.dmLog.findUnique.mockResolvedValue(null);
+  mockPrisma.dmLog.create.mockResolvedValue({});
   mockPrisma.dmLog.upsert.mockResolvedValue({});
   mockPrisma.dmLog.update.mockResolvedValue({});
   mockPrisma.instagramAccount.findUnique.mockResolvedValue({
@@ -340,7 +342,7 @@ describe("DM Worker — Full Pipeline", () => {
       }),
       expect.objectContaining({
         delay: 1800000,
-        jobId: "comment:ig_456:comment_555:retry:1",
+        jobId: "comment_ig_456_comment_555_retry_1",
       })
     );
   });


### PR DESCRIPTION
CI on main has been failing since 1059afd ("Retry the public reply when it
fails after the DM already sent"). Two separate causes, both in the test file:

1. That commit added `prisma.dmLog.create(...)` to processComment, but the
   hoisted prisma mock only stubs findUnique/upsert/update — so six tests died
   on "prisma.dmLog.create is not a function".

2. One assertion still expects the old colon-delimited requeue job id
   (`comment:ig_456:comment_555:retry:1"`). The codebase settled on
   underscores: app/api/webhook/route.ts builds `comment_${igId}_${commentId}`
   and the worker builds the matching `..._retry_${n}`. The code is right and
   internally consistent, so I fixed the assertion rather than the id format —
   BullMQ dedupes on job id, so changing the format would silently break
   dedupe against jobs already queued in a running deployment.

No production code touched. 95/95 tests pass, typecheck and lint clean.
