### PR TITLE
Reply to DMs that match a campaign's keywords

### DIFF
--- a/__tests__/dm-worker.test.ts
+++ b/__tests__/dm-worker.test.ts
@@ -112,6 +112,7 @@ vi.mock("@/lib/queue/client", () => ({
   getRedisConnection: vi.fn(),
   POSTBACK_JOB_NAME: "process-postback",
   FOLLOWUP_JOB_NAME: "process-followup",
+  MESSAGE_JOB_NAME: "process-message",
 }));
 
 vi.mock("bullmq", () => {
@@ -892,6 +893,193 @@ describe("DM Worker — one private reply per comment", () => {
     expect(mockPrisma.dmLog.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({ status: "SENT" }),
+      })
+    );
+  });
+});
+
+describe("DM Worker — DM keyword trigger", () => {
+  const dmTriggerAutomation = {
+    ...mockAutomation,
+    dmTriggerEnabled: true,
+    requireFollow: false,
+    followPromptMessage: null,
+    followPromptButtonLabel: null,
+  };
+
+  function createMockMessageJob(data: Record<string, unknown> = {}) {
+    return {
+      name: "process-message",
+      data: {
+        instagramAccountId: "ig_456",
+        messageId: "mid_abc",
+        messageText: "can I get the LINK?",
+        senderId: "commenter_999",
+        ...data,
+      },
+      id: "message_job_001",
+      attemptsMade: 0,
+    };
+  }
+
+  beforeEach(() => {
+    mockPrisma.automation.findMany.mockResolvedValue([dmTriggerAutomation]);
+  });
+
+  it("should reply to a DM whose text matches the campaign keywords", async () => {
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockPrisma.automation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          dmTriggerEnabled: true,
+          isActive: true,
+        }),
+      })
+    );
+    expect(mockSendDirectMessage).toHaveBeenCalledWith(
+      "decrypted_token",
+      "ig_456",
+      "commenter_999",
+      "Hey commenter_user! Here is the link: https://example.com"
+    );
+    // Never a private reply — there is no comment to reply to.
+    expect(mockSendPrivateReply).not.toHaveBeenCalled();
+  });
+
+  it("should not reply when the DM text matches no keyword", async () => {
+    mockMatchKeywords.mockReturnValue({ matched: false, matchedKeyword: null });
+
+    const processor = getProcessor();
+    await processor(createMockMessageJob({ messageText: "hello there" }));
+
+    expect(mockSendDirectMessage).not.toHaveBeenCalled();
+    expect(mockSendDirectMessageWithLinkButton).not.toHaveBeenCalled();
+  });
+
+  it("should log the reply against the inbound message id for dedup", async () => {
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockPrisma.dmLog.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          automationId_commentId: {
+            automationId: "auto_789",
+            commentId: "dm:mid_abc",
+          },
+        },
+        create: expect.objectContaining({
+          commenterId: "commenter_999",
+          commentText: "can I get the LINK?",
+          matchedKeyword: "LINK",
+          status: "SENT",
+        }),
+      })
+    );
+  });
+
+  it("should not re-send when this message was already answered", async () => {
+    mockPrisma.dmLog.findUnique.mockResolvedValue({ status: "SENT" });
+
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockSendDirectMessage).not.toHaveBeenCalled();
+    expect(mockReserveWorkspaceDMSend).not.toHaveBeenCalled();
+  });
+
+  it("should send the link as buttons when the campaign has tracked links", async () => {
+    mockPrisma.automation.findMany.mockResolvedValue([
+      {
+        ...dmTriggerAutomation,
+        linkButtonLabel: "Get it",
+        trackedLinks: [
+          {
+            slug: "abc123",
+            label: "Get it",
+            destinationUrl: "https://example.com/offer",
+          },
+        ],
+      },
+    ]);
+
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockSendDirectMessageWithLinkButton).toHaveBeenCalled();
+    expect(mockSendDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it("should send the follow prompt instead of the link to a non-follower", async () => {
+    mockPrisma.automation.findMany.mockResolvedValue([
+      { ...dmTriggerAutomation, requireFollow: true },
+    ]);
+    mockGetUserFollowStatus.mockResolvedValue(false);
+
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockSendDirectMessageWithButton).toHaveBeenCalledWith(
+      "decrypted_token",
+      "ig_456",
+      "commenter_999",
+      expect.any(String),
+      "I'm following ✅",
+      "followcheck:auto_789"
+    );
+    expect(mockSendDirectMessage).not.toHaveBeenCalled();
+  });
+
+  it("should send the link when follow status cannot be verified", async () => {
+    mockPrisma.automation.findMany.mockResolvedValue([
+      { ...dmTriggerAutomation, requireFollow: true },
+    ]);
+    mockGetUserFollowStatus.mockResolvedValue(null);
+
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockSendDirectMessage).toHaveBeenCalled();
+    expect(mockSendDirectMessageWithButton).not.toHaveBeenCalled();
+  });
+
+  it("should skip and log when the workspace is over its monthly limit", async () => {
+    mockReserveWorkspaceDMSend.mockResolvedValue({
+      allowed: false,
+      reserved: false,
+      remaining: 0,
+      limit: 2000,
+      periodStart: usagePeriodStart,
+    });
+
+    const processor = getProcessor();
+    await processor(createMockMessageJob());
+
+    expect(mockSendDirectMessage).not.toHaveBeenCalled();
+    expect(mockPrisma.dmLog.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ status: "SKIPPED_PLAN_LIMIT" }),
+      })
+    );
+  });
+
+  it("should release the usage reservation and rethrow when the send fails", async () => {
+    mockSendDirectMessage.mockRejectedValue(new Error("Meta is down"));
+
+    const processor = getProcessor();
+    await expect(processor(createMockMessageJob())).rejects.toThrow(
+      "Meta is down"
+    );
+
+    expect(mockReleaseWorkspaceDMReservation).toHaveBeenCalledWith(
+      "workspace_123",
+      usagePeriodStart
+    );
+    expect(mockPrisma.dmLog.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ status: "FAILED" }),
       })
     );
   });

--- a/__tests__/webhook.test.ts
+++ b/__tests__/webhook.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   verifyWebhookSignature,
   parseCommentEvents,
+  parseMessageEvents,
   parseReadEvents,
 } from "../lib/meta/webhook";
 import { createHmac } from "crypto";
@@ -287,6 +288,121 @@ describe("parseCommentEvents", () => {
 
     const events = parseCommentEvents(payload);
     expect(events).toHaveLength(0);
+  });
+});
+
+describe("parseMessageEvents", () => {
+  function messagingPayload(messaging: unknown[]) {
+    return {
+      object: "instagram",
+      entry: [{ id: "ig_456", time: 1234567890, messaging }],
+    } as Parameters<typeof parseMessageEvents>[0];
+  }
+
+  it("should parse an inbound DM", () => {
+    const payload = messagingPayload([
+      {
+        sender: { id: "user_999" },
+        recipient: { id: "ig_456" },
+        message: { mid: "mid_abc", text: "send me the LINK please" },
+      },
+    ]);
+
+    expect(parseMessageEvents(payload)).toEqual([
+      {
+        instagramAccountId: "ig_456",
+        messageId: "mid_abc",
+        messageText: "send me the LINK please",
+        senderId: "user_999",
+      },
+    ]);
+  });
+
+  it("should ignore echoes of the account's own messages", () => {
+    const payload = messagingPayload([
+      {
+        sender: { id: "ig_456" },
+        recipient: { id: "user_999" },
+        message: { mid: "mid_abc", text: "here's your link", is_echo: true },
+      },
+    ]);
+
+    expect(parseMessageEvents(payload)).toHaveLength(0);
+  });
+
+  it("should ignore deleted and unsupported messages", () => {
+    expect(
+      parseMessageEvents(
+        messagingPayload([
+          {
+            sender: { id: "user_999" },
+            recipient: { id: "ig_456" },
+            message: { mid: "mid_a", text: "link", is_deleted: true },
+          },
+          {
+            sender: { id: "user_999" },
+            recipient: { id: "ig_456" },
+            message: { mid: "mid_b", text: "link", is_unsupported: true },
+          },
+        ])
+      )
+    ).toHaveLength(0);
+  });
+
+  it("should ignore attachment-only messages with no text", () => {
+    const payload = messagingPayload([
+      {
+        sender: { id: "user_999" },
+        recipient: { id: "ig_456" },
+        message: { mid: "mid_abc", attachments: [{ type: "image" }] },
+      },
+    ]);
+
+    expect(parseMessageEvents(payload)).toHaveLength(0);
+  });
+
+  it("should ignore messages the account sent to itself", () => {
+    const payload = messagingPayload([
+      {
+        sender: { id: "ig_456" },
+        recipient: { id: "ig_456" },
+        message: { mid: "mid_abc", text: "link" },
+      },
+    ]);
+
+    expect(parseMessageEvents(payload)).toHaveLength(0);
+  });
+
+  it("should ignore postback events that carry no message", () => {
+    const payload = messagingPayload([
+      {
+        sender: { id: "user_999" },
+        recipient: { id: "ig_456" },
+        postback: { mid: "mid_abc", payload: "reveal:auto_1" },
+      },
+    ]);
+
+    expect(parseMessageEvents(payload)).toHaveLength(0);
+  });
+
+  it("should ignore non-instagram payloads", () => {
+    expect(
+      parseMessageEvents({
+        object: "page",
+        entry: [
+          {
+            id: "ig_456",
+            time: 1,
+            messaging: [
+              {
+                sender: { id: "user_999" },
+                message: { mid: "mid_abc", text: "link" },
+              },
+            ],
+          },
+        ],
+      })
+    ).toHaveLength(0);
   });
 });
 

--- a/app/(dashboard)/campaigns/[id]/page.tsx
+++ b/app/(dashboard)/campaigns/[id]/page.tsx
@@ -22,6 +22,7 @@ interface Campaign {
   matchAnyPost: boolean;
   keywords: string[];
   matchAnyWord: boolean;
+  dmTriggerEnabled: boolean;
   dmMessage: string;
   openingDmEnabled: boolean;
   openingDmMessage: string | null;
@@ -211,6 +212,12 @@ export default function CampaignDetailPage() {
 
         <Summary title="And this comment has">
           <FieldBox>{matchText}</FieldBox>
+          {campaign.dmTriggerEnabled && (
+            <p className="text-xs text-muted">
+              Also replies when someone DMs{" "}
+              {campaign.matchAnyWord ? "anything" : "these words"}.
+            </p>
+          )}
           {publicReplies.length > 0 && (
             <div className="space-y-1.5">
               <p className="text-xs text-muted">Public reply under the post</p>
@@ -339,6 +346,7 @@ export default function CampaignDetailPage() {
             postThumb={postThumb}
             caption=""
             sampleComment={campaign.matchAnyWord ? "nice!" : campaign.keywords[0] ?? "LINK"}
+            dmTriggerEnabled={campaign.dmTriggerEnabled}
             publicReplyEnabled={campaign.publicReplyEnabled}
             publicReplyMessage={publicReplies[0] ?? ""}
             openingDmEnabled={campaign.openingDmEnabled}

--- a/app/api/automations/route.ts
+++ b/app/api/automations/route.ts
@@ -26,6 +26,7 @@ const createAutomationSchema = z
     matchAnyPost: z.boolean().optional().default(false),
     keywords: z.array(z.string().min(1).max(50)).max(10).optional().default([]),
     matchAnyWord: z.boolean().optional().default(false),
+    dmTriggerEnabled: z.boolean().optional().default(false),
     dmMessage: z.string().min(1).max(1000),
     openingDmEnabled: z.boolean().optional().default(false),
     openingDmMessage: z.string().max(1000).optional().nullable(),
@@ -88,6 +89,7 @@ const updateAutomationSchema = z.object({
   matchAnyPost: z.boolean().optional(),
   keywords: z.array(z.string().min(1).max(50)).max(10).optional(),
   matchAnyWord: z.boolean().optional(),
+  dmTriggerEnabled: z.boolean().optional(),
   dmMessage: z.string().min(1).max(1000).optional(),
   openingDmEnabled: z.boolean().optional(),
   openingDmMessage: z.string().max(1000).optional().nullable(),
@@ -392,6 +394,7 @@ export async function POST(request: NextRequest) {
       matchAnyPost,
       keywords: matchAnyWord ? [] : parsed.data.keywords,
       matchAnyWord,
+      dmTriggerEnabled: parsed.data.dmTriggerEnabled,
       dmMessage: parsed.data.dmMessage,
       openingDmEnabled,
       openingDmMessage: openingDmEnabled

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -3,11 +3,12 @@ import { prisma } from "@/lib/db/client";
 import { getDMQueue } from "@/lib/queue/client";
 import {
   parseCommentEvents,
+  parseMessageEvents,
   parsePostbackEvents,
   parseReadEvents,
   verifyWebhookSignature,
 } from "@/lib/meta/webhook";
-import { POSTBACK_JOB_NAME } from "@/lib/queue/client";
+import { MESSAGE_JOB_NAME, POSTBACK_JOB_NAME } from "@/lib/queue/client";
 import { Prisma } from "@/app/generated/prisma/client";
 
 const OPENING_DM_READ_FALLBACK_DELAY_MS = 5 * 60 * 1000;
@@ -135,6 +136,43 @@ export async function POST(request: NextRequest) {
           ).replace(/:/g, "_")}`,
         }
       );
+    }
+
+    // Inbound DMs → keyword-triggered autoreply.
+    const messageEvents = parseMessageEvents(
+      payload as Parameters<typeof parseMessageEvents>[0]
+    );
+
+    for (const event of messageEvents) {
+      const account = await prisma.instagramAccount.findUnique({
+        where: { instagramId: event.instagramAccountId },
+        select: { workspaceId: true },
+      });
+
+      await queue.add(
+        MESSAGE_JOB_NAME,
+        {
+          instagramAccountId: event.instagramAccountId,
+          messageId: event.messageId,
+          messageText: event.messageText,
+          senderId: event.senderId,
+        },
+        {
+          // Message ids can contain characters BullMQ rejects in a job id
+          // (":" in particular), so normalize them out.
+          jobId: `message_${event.instagramAccountId}_${event.messageId.replace(
+            /[^A-Za-z0-9_-]/g,
+            "_"
+          )}`,
+        }
+      );
+
+      if (account) {
+        await prisma.webhookEvent.update({
+          where: { id: webhookEvent.id },
+          data: { workspaceId: account.workspaceId },
+        });
+      }
     }
 
     // If a user reads the opening DM and never taps the button, deliver the

--- a/components/campaign-builder.tsx
+++ b/components/campaign-builder.tsx
@@ -36,6 +36,7 @@ interface LoadedCampaign {
   matchAnyPost: boolean;
   keywords: string[];
   matchAnyWord: boolean;
+  dmTriggerEnabled: boolean;
   dmMessage: string;
   openingDmEnabled: boolean;
   openingDmMessage: string | null;
@@ -156,6 +157,7 @@ export default function CampaignBuilder({ mode, campaignId }: CampaignBuilderPro
 
   const [matchMode, setMatchMode] = useState<MatchMode>("specific");
   const [keywordText, setKeywordText] = useState("");
+  const [dmTriggerEnabled, setDmTriggerEnabled] = useState(false);
 
   const [publicReplyEnabled, setPublicReplyEnabled] = useState(false);
   const [publicReplyMessages, setPublicReplyMessages] = useState<string[]>([""]);
@@ -256,6 +258,7 @@ export default function CampaignBuilder({ mode, campaignId }: CampaignBuilderPro
         setPostUrl(c.postUrl);
         setMatchMode(c.matchAnyWord ? "any" : "specific");
         setKeywordText(c.keywords.join(", "));
+        setDmTriggerEnabled(c.dmTriggerEnabled ?? false);
         setPublicReplyEnabled(c.publicReplyEnabled);
         setPublicReplyMessages(
           c.publicReplyMessages?.length
@@ -403,6 +406,7 @@ export default function CampaignBuilder({ mode, campaignId }: CampaignBuilderPro
       pendingNextReel: triggerScope === "next",
       matchAnyWord: matchMode === "any",
       keywords: matchMode === "any" ? [] : keywords,
+      dmTriggerEnabled,
       dmMessage,
       openingDmEnabled,
       openingDmMessage: openingDmEnabled ? openingDmMessage : null,
@@ -716,6 +720,23 @@ export default function CampaignBuilder({ mode, campaignId }: CampaignBuilderPro
           >
             any word
           </Radio>
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2.5">
+            <span className="text-sm text-foreground">
+              also reply when someone DMs{" "}
+              {matchMode === "any" ? "anything" : "these words"}
+            </span>
+            <Toggle
+              on={dmTriggerEnabled}
+              onToggle={() => setDmTriggerEnabled(!dmTriggerEnabled)}
+            />
+          </div>
+          {dmTriggerEnabled && (
+            <p className="text-xs text-muted">
+              {matchMode === "any"
+                ? "Every DM to this account gets the reply below — use with care."
+                : "A DM containing any of these words gets the same reply, no comment needed."}
+            </p>
+          )}
           <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
             <span className="text-sm text-foreground">
               reply to their comments under the post
@@ -970,6 +991,7 @@ export default function CampaignBuilder({ mode, campaignId }: CampaignBuilderPro
             postThumb={postThumb}
             caption={postCaption}
             sampleComment={keywords[0] ?? ""}
+            dmTriggerEnabled={dmTriggerEnabled}
             publicReplyEnabled={publicReplyEnabled}
             publicReplyMessage={publicReplyMessages.find((m) => m.trim()) ?? ""}
             openingDmEnabled={openingDmEnabled}

--- a/components/campaign-preview.tsx
+++ b/components/campaign-preview.tsx
@@ -10,7 +10,7 @@
  * the identical frame so switching tabs never resizes the phone.
  */
 
-export type PreviewTab = "post" | "comments" | "dm";
+export type PreviewTab = "post" | "comments" | "dm" | "dmTrigger";
 
 interface CampaignPreviewProps {
   tab: PreviewTab;
@@ -20,6 +20,9 @@ interface CampaignPreviewProps {
   postThumb: string | null;
   caption: string;
   sampleComment: string;
+  // The DM keyword trigger gets its own thread: the user messages first, and
+  // the opening DM is skipped because the conversation is already open.
+  dmTriggerEnabled: boolean;
   publicReplyEnabled: boolean;
   publicReplyMessage: string;
   openingDmEnabled: boolean;
@@ -318,6 +321,7 @@ function DmScreen({
   followUpMessage,
   followUpDelayMinutes = 0,
   linkUrl,
+  inboundMessage,
 }: {
   username: string;
   avatarUrl: string | null;
@@ -336,6 +340,8 @@ function DmScreen({
   followUpEnabled: boolean;
   followUpMessage: string;
   followUpDelayMinutes?: number;
+  // Present on the keyword-trigger thread: the DM the user sends to start it.
+  inboundMessage?: string;
 }) {
   return (
     <div className="flex h-full flex-col text-white">
@@ -351,6 +357,13 @@ function DmScreen({
       </div>
 
       <div className="flex-1 space-y-3 px-3 py-4">
+        {inboundMessage !== undefined && (
+          <div className="flex justify-end">
+            <div className="max-w-[80%] rounded-2xl rounded-br-md bg-accent px-3 py-2 text-sm">
+              {inboundMessage || "their message"}
+            </div>
+          </div>
+        )}
         {openingDmEnabled && (
           <>
             <div className="flex items-end gap-2">
@@ -465,12 +478,20 @@ export default function CampaignPreview(props: CampaignPreviewProps) {
     { key: "post", label: "Post" },
     { key: "comments", label: "Comments" },
     { key: "dm", label: "DM" },
+    ...(props.dmTriggerEnabled
+      ? [{ key: "dmTrigger" as const, label: "DM trigger" }]
+      : []),
   ];
+
+  // The DM-trigger tab disappears when the trigger is switched off; fall back
+  // to the comment thread rather than rendering an empty phone.
+  const activeTab: PreviewTab =
+    tab === "dmTrigger" && !props.dmTriggerEnabled ? "dm" : tab;
 
   return (
     <div className="flex flex-col items-center gap-5">
       <Phone>
-        {tab === "post" && (
+        {activeTab === "post" && (
           <PostScreen
             username={props.username}
             avatarUrl={props.avatarUrl}
@@ -478,7 +499,7 @@ export default function CampaignPreview(props: CampaignPreviewProps) {
             caption={props.caption}
           />
         )}
-        {tab === "comments" && (
+        {activeTab === "comments" && (
           <CommentsScreen
             username={props.username}
             avatarUrl={props.avatarUrl}
@@ -487,7 +508,7 @@ export default function CampaignPreview(props: CampaignPreviewProps) {
             publicReplyMessage={props.publicReplyMessage}
           />
         )}
-        {tab === "dm" && (
+        {activeTab === "dm" && (
           <DmScreen
             username={props.username}
             avatarUrl={props.avatarUrl}
@@ -508,6 +529,29 @@ export default function CampaignPreview(props: CampaignPreviewProps) {
             linkUrl={props.linkUrl}
           />
         )}
+        {activeTab === "dmTrigger" && (
+          <DmScreen
+            username={props.username}
+            avatarUrl={props.avatarUrl}
+            // The user opened the conversation, so no opening DM is sent.
+            openingDmEnabled={false}
+            openingDmMessage=""
+            openingDmButtonLabel=""
+            revealMessage={props.revealMessage}
+            hasLink={props.hasLink}
+            linkButtonLabel={props.linkButtonLabel}
+            hasSecondLink={props.hasSecondLink}
+            secondLinkButtonLabel={props.secondLinkButtonLabel}
+            requireFollow={props.requireFollow}
+            followPromptMessage={props.followPromptMessage}
+            followPromptButtonLabel={props.followPromptButtonLabel}
+            followUpEnabled={props.followUpEnabled}
+            followUpMessage={props.followUpMessage}
+            followUpDelayMinutes={props.followUpDelayMinutes}
+            linkUrl={props.linkUrl}
+            inboundMessage={props.sampleComment}
+          />
+        )}
       </Phone>
 
       <div className="inline-flex rounded-full bg-surface p-1">
@@ -517,7 +561,7 @@ export default function CampaignPreview(props: CampaignPreviewProps) {
             type="button"
             onClick={() => onTabChange(t.key)}
             className={`rounded-full px-4 py-1.5 text-sm transition-colors ${
-              tab === t.key
+              activeTab === t.key
                 ? "bg-background font-medium text-foreground ring-1 ring-accent/40"
                 : "text-muted hover:text-foreground"
             }`}

--- a/lib/meta/webhook.ts
+++ b/lib/meta/webhook.ts
@@ -65,7 +65,22 @@ interface WebhookEntry {
     recipient?: { id?: string };
     postback?: { mid?: string; title?: string; payload?: string };
     read?: { watermark?: number; seq?: number };
+    message?: {
+      mid?: string;
+      text?: string;
+      is_echo?: boolean;
+      is_deleted?: boolean;
+      is_unsupported?: boolean;
+      attachments?: Array<{ type?: string }>;
+    };
   }>;
+}
+
+export interface WebhookMessageEvent {
+  instagramAccountId: string;
+  messageId: string;
+  messageText: string;
+  senderId: string;
 }
 
 export interface WebhookPostbackEvent {
@@ -153,6 +168,52 @@ export function parsePostbackEvents(
         userId,
         payload: postbackPayload,
         mid: messaging.postback?.mid,
+      });
+    }
+  }
+
+  return events;
+}
+
+/**
+ * Parse inbound Instagram DMs out of a webhook payload. These drive the
+ * keyword-triggered autoreply: a user messages the account, and a campaign
+ * with `dmTriggerEnabled` whose keywords match the text replies to them.
+ *
+ * Echoes (messages the account itself sent, including our own autoreplies),
+ * deletions, and attachment-only messages with no text are dropped here so
+ * the worker never sees them — an echo would otherwise let an autoreply
+ * containing its own keyword trigger itself.
+ */
+export function parseMessageEvents(
+  payload: WebhookPayload
+): WebhookMessageEvent[] {
+  const events: WebhookMessageEvent[] = [];
+
+  if (payload.object !== "instagram") return events;
+
+  for (const entry of payload.entry ?? []) {
+    for (const messaging of entry.messaging ?? []) {
+      const message = messaging.message;
+      if (!message) continue;
+      if (message.is_echo || message.is_deleted || message.is_unsupported) {
+        continue;
+      }
+
+      const text = message.text?.trim();
+      const messageId = message.mid;
+      const senderId = messaging.sender?.id;
+      const accountId = entry.id ?? messaging.recipient?.id;
+
+      if (!text || !messageId || !senderId || !accountId) continue;
+      // Ignore anything the connected account sent to itself.
+      if (senderId === accountId) continue;
+
+      events.push({
+        instagramAccountId: accountId,
+        messageId,
+        messageText: text,
+        senderId,
       });
     }
   }

--- a/lib/queue/client.ts
+++ b/lib/queue/client.ts
@@ -54,13 +54,24 @@ export interface ProcessFollowUpJob {
   commenterName?: string | null;
 }
 
+// An inbound DM from a user. Campaigns with `dmTriggerEnabled` whose keywords
+// match the text reply to the sender.
+export interface ProcessMessageJob {
+  instagramAccountId: string;
+  messageId: string;
+  messageText: string;
+  senderId: string;
+}
+
 export type DmQueueJob =
   | ProcessCommentJob
   | ProcessPostbackJob
-  | ProcessFollowUpJob;
+  | ProcessFollowUpJob
+  | ProcessMessageJob;
 
 export const POSTBACK_JOB_NAME = "process-postback";
 export const FOLLOWUP_JOB_NAME = "process-followup";
+export const MESSAGE_JOB_NAME = "process-message";
 
 let dmQueue: Queue<DmQueueJob> | null = null;
 

--- a/lib/queue/dm-worker.ts
+++ b/lib/queue/dm-worker.ts
@@ -2,10 +2,12 @@ import { Worker, type Job } from "bullmq";
 import {
   getDMQueue,
   getRedisConnection,
+  MESSAGE_JOB_NAME,
   POSTBACK_JOB_NAME,
   FOLLOWUP_JOB_NAME,
   type DmQueueJob,
   type ProcessCommentJob,
+  type ProcessMessageJob,
   type ProcessPostbackJob,
   type ProcessFollowUpJob,
 } from "./client";
@@ -105,6 +107,85 @@ function buildInlineLinkFallback(
     bodyText;
   const extraUrls = trackedLinks.slice(1).map((link) => buildTrackedUrl(link.slug));
   return extraUrls.length > 0 ? `${base}\n${extraUrls.join("\n")}` : base;
+}
+
+type RevealAutomation = {
+  dmMessage: string;
+  linkButtonLabel: string | null;
+  trackedLinks: WorkerTrackedLink[];
+  instagramAccount: { instagramId: string };
+};
+
+/**
+ * Deliver a campaign's reveal message as a direct message. Shared by the
+ * button-tap (postback) path and the DM keyword-trigger path — both already
+ * have an open conversation with the user, so neither uses a private reply.
+ */
+async function sendRevealDirectMessage(
+  accessToken: string,
+  automation: RevealAutomation,
+  userId: string,
+  commenterName: string | null,
+  context: string
+): Promise<void> {
+  if (automation.trackedLinks.length === 0) {
+    await sendDirectMessage(
+      accessToken,
+      automation.instagramAccount.instagramId,
+      userId,
+      renderMessageWithTracking({
+        message: automation.dmMessage,
+        commenterName,
+        trackedLinks: automation.trackedLinks,
+      })
+    );
+    return;
+  }
+
+  // Try button template first; if Meta rejects it, fall back to inline links.
+  const bodyText =
+    renderMessageWithoutLink({
+      message: automation.dmMessage,
+      commenterName,
+    }) || "Here's your link:";
+  const buttons = buildLinkButtons(
+    automation.trackedLinks,
+    automation.linkButtonLabel
+  );
+
+  try {
+    await sendDirectMessageWithLinkButton(
+      accessToken,
+      automation.instagramAccount.instagramId,
+      userId,
+      bodyText,
+      buttons
+    );
+  } catch (buttonError) {
+    // A closed messaging window rejects the text retry too, so don't let it
+    // overwrite the original error with a misleading one.
+    if (!isTemplateRejection(buttonError)) throw buttonError;
+
+    console.log(
+      `[DM Worker] Button template rejected in ${context}, falling back to inline link:`,
+      formatError(buttonError)
+    );
+    try {
+      await sendDirectMessage(
+        accessToken,
+        automation.instagramAccount.instagramId,
+        userId,
+        buildInlineLinkFallback(
+          automation.dmMessage,
+          commenterName,
+          automation.trackedLinks,
+          bodyText
+        )
+      );
+    } catch {
+      throw buttonError;
+    }
+  }
 }
 
 async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
@@ -714,65 +795,13 @@ async function processPostback(job: Job<ProcessPostbackJob>): Promise<void> {
   }
 
   try {
-    if (automation.trackedLinks.length > 0) {
-      // Try button template first; if Meta rejects it, fall back to inline links.
-      const bodyText =
-        renderMessageWithoutLink({
-          message: automation.dmMessage,
-          commenterName,
-        }) || "Here's your link:";
-      const buttons = buildLinkButtons(
-        automation.trackedLinks,
-        automation.linkButtonLabel
-      );
-
-      try {
-        await sendDirectMessageWithLinkButton(
-          accessToken,
-          automation.instagramAccount.instagramId,
-          userId,
-          bodyText,
-          buttons
-        );
-      } catch (buttonError) {
-        // As in processComment: a closed messaging window rejects the text
-        // retry too, so don't let it overwrite the original error.
-        if (!isTemplateRejection(buttonError)) throw buttonError;
-
-        console.log(
-          "[DM Worker] Button template rejected in postback, falling back to inline link:",
-          formatError(buttonError)
-        );
-        const fallbackMessage = buildInlineLinkFallback(
-          automation.dmMessage,
-          commenterName,
-          automation.trackedLinks,
-          bodyText
-        );
-        try {
-          await sendDirectMessage(
-            accessToken,
-            automation.instagramAccount.instagramId,
-            userId,
-            fallbackMessage
-          );
-        } catch {
-          throw buttonError;
-        }
-      }
-    } else {
-      const revealMessage = renderMessageWithTracking({
-        message: automation.dmMessage,
-        commenterName,
-        trackedLinks: automation.trackedLinks,
-      });
-      await sendDirectMessage(
-        accessToken,
-        automation.instagramAccount.instagramId,
-        userId,
-        revealMessage
-      );
-    }
+    await sendRevealDirectMessage(
+      accessToken,
+      automation,
+      userId,
+      commenterName,
+      "postback"
+    );
     // Optional appreciation follow-up: once the link has been delivered, send a
     // short thank-you. It is scheduled as its own delayed job so it can go out
     // some minutes later (followUpDelayMinutes) rather than immediately. The
@@ -898,12 +927,262 @@ async function processFollowUp(job: Job<ProcessFollowUpJob>): Promise<void> {
   }
 }
 
+/**
+ * Reply to an inbound DM whose text matches a campaign's keywords.
+ *
+ * The user has messaged us, so the conversation is already open: this path
+ * skips the opening DM (which exists to work around private-reply limits from
+ * comments) and delivers the reveal directly, honouring the follow gate.
+ * Dedup is per inbound message id, so each message triggers at most one reply.
+ */
+async function processMessage(job: Job<ProcessMessageJob>): Promise<void> {
+  const { instagramAccountId, messageId, messageText, senderId } = job.data;
+
+  const automations = await prisma.automation.findMany({
+    where: {
+      dmTriggerEnabled: true,
+      isActive: true,
+      instagramAccount: { instagramId: instagramAccountId },
+    },
+    include: {
+      instagramAccount: true,
+      workspace: true,
+      trackedLinks: {
+        select: { slug: true, label: true, destinationUrl: true },
+        orderBy: { createdAt: "asc" },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  const dedupeId = `dm:${messageId}`;
+
+  for (const automation of automations) {
+    const matchResult = automation.matchAnyWord
+      ? { matched: true, matchedKeyword: null }
+      : matchKeywords(
+          messageText,
+          automation.keywords,
+          automation.wholeWordMatch
+        );
+
+    if (!matchResult.matched) continue;
+
+    const existingLog = await prisma.dmLog.findUnique({
+      where: {
+        automationId_commentId: {
+          automationId: automation.id,
+          commentId: dedupeId,
+        },
+      },
+    });
+
+    // Already replied to this message (or deliberately skipped it) — a retry
+    // of the job must not send a second DM.
+    if (
+      existingLog?.status === "SENT" ||
+      existingLog?.status === "SKIPPED_PLAN_LIMIT"
+    ) {
+      continue;
+    }
+
+    const logBase = {
+      workspaceId: automation.workspaceId,
+      automationId: automation.id,
+      instagramAccountId: automation.instagramAccountId,
+      commenterId: senderId,
+      commentText: messageText,
+      commentId: dedupeId,
+      matchedKeyword: matchResult.matchedKeyword,
+    };
+
+    if (!automation.instagramAccount.accessToken) {
+      await prisma.dmLog.upsert({
+        where: {
+          automationId_commentId: {
+            automationId: automation.id,
+            commentId: dedupeId,
+          },
+        },
+        create: {
+          ...logBase,
+          status: "FAILED",
+          errorMessage: "No Instagram access token available",
+        },
+        update: {
+          status: "FAILED",
+          errorMessage: "No Instagram access token available",
+        },
+      });
+      continue;
+    }
+
+    let accessToken: string;
+    try {
+      accessToken = decryptToken(automation.instagramAccount.accessToken);
+    } catch {
+      await prisma.dmLog.upsert({
+        where: {
+          automationId_commentId: {
+            automationId: automation.id,
+            commentId: dedupeId,
+          },
+        },
+        create: {
+          ...logBase,
+          status: "FAILED",
+          errorMessage: "Failed to decrypt Instagram access token",
+        },
+        update: {
+          status: "FAILED",
+          errorMessage: "Failed to decrypt Instagram access token",
+        },
+      });
+      continue;
+    }
+
+    // Reuse a name captured on an earlier interaction so {username} still
+    // renders — the messages webhook carries only the sender's IGSID.
+    const priorLog = await prisma.dmLog.findFirst({
+      where: { automationId: automation.id, commenterId: senderId },
+      select: { commenterName: true },
+    });
+    const commenterName = priorLog?.commenterName ?? null;
+
+    // Follow gate: a non-follower gets the prompt instead of the link, with the
+    // same `followcheck:` button that re-verifies on tap. `null` (unverifiable)
+    // falls through to the link, matching the comment path's fail-open rule.
+    let sendFollowPrompt = false;
+    if (automation.requireFollow) {
+      const follows = await getUserFollowStatus(accessToken, senderId);
+      sendFollowPrompt = follows === false;
+    }
+
+    const usage = await reserveWorkspaceDMSend(automation.workspaceId);
+    if (!usage.allowed) {
+      await prisma.dmLog.upsert({
+        where: {
+          automationId_commentId: {
+            automationId: automation.id,
+            commentId: dedupeId,
+          },
+        },
+        create: {
+          ...logBase,
+          status: "SKIPPED_PLAN_LIMIT",
+          errorMessage: `Monthly DM limit reached (${usage.limit})`,
+        },
+        update: {
+          status: "SKIPPED_PLAN_LIMIT",
+          errorMessage: `Monthly DM limit reached (${usage.limit})`,
+        },
+      });
+      continue;
+    }
+
+    try {
+      if (sendFollowPrompt) {
+        const promptText = renderMessageWithoutLink({
+          message:
+            automation.followPromptMessage ||
+            "Almost there! Follow me and tap the button below to grab your link 💛",
+          commenterName,
+        });
+        await sendDirectMessageWithButton(
+          accessToken,
+          automation.instagramAccount.instagramId,
+          senderId,
+          promptText,
+          automation.followPromptButtonLabel || "I'm following ✅",
+          `followcheck:${automation.id}`
+        );
+      } else {
+        await sendRevealDirectMessage(
+          accessToken,
+          automation,
+          senderId,
+          commenterName,
+          "message trigger"
+        );
+
+        // The link has been delivered, so the appreciation follow-up applies
+        // here exactly as it does after a button tap. Not scheduled behind the
+        // follow prompt — no link went out yet in that branch.
+        if (automation.followUpEnabled && automation.followUpMessage?.trim()) {
+          await getDMQueue().add(
+            FOLLOWUP_JOB_NAME,
+            {
+              instagramAccountId: automation.instagramAccount.instagramId,
+              userId: senderId,
+              automationId: automation.id,
+              commenterName,
+            },
+            {
+              delay: Math.max(0, automation.followUpDelayMinutes ?? 0) * 60_000,
+              jobId: `followup_${automation.id}_${senderId}`,
+            }
+          );
+        }
+      }
+
+      await prisma.dmLog.upsert({
+        where: {
+          automationId_commentId: {
+            automationId: automation.id,
+            commentId: dedupeId,
+          },
+        },
+        create: {
+          ...logBase,
+          commenterName,
+          status: "SENT",
+          dmSentAt: new Date(),
+        },
+        update: {
+          status: "SENT",
+          dmSentAt: new Date(),
+          errorMessage: null,
+        },
+      });
+    } catch (error) {
+      await releaseWorkspaceDMReservation(
+        automation.workspaceId,
+        usage.periodStart
+      );
+      await prisma.dmLog.upsert({
+        where: {
+          automationId_commentId: {
+            automationId: automation.id,
+            commentId: dedupeId,
+          },
+        },
+        create: {
+          ...logBase,
+          commenterName,
+          status: "FAILED",
+          attempts: job.attemptsMade + 1,
+          errorMessage: formatError(error),
+        },
+        update: {
+          status: "FAILED",
+          attempts: job.attemptsMade + 1,
+          errorMessage: formatError(error),
+        },
+      });
+      throw error;
+    }
+  }
+}
+
 async function processJob(job: Job<DmQueueJob>): Promise<void> {
   if (job.name === POSTBACK_JOB_NAME) {
     return processPostback(job as Job<ProcessPostbackJob>);
   }
   if (job.name === FOLLOWUP_JOB_NAME) {
     return processFollowUp(job as Job<ProcessFollowUpJob>);
+  }
+  if (job.name === MESSAGE_JOB_NAME) {
+    return processMessage(job as Job<ProcessMessageJob>);
   }
   return processComment(job as Job<ProcessCommentJob>);
 }

--- a/prisma/migrations/20260731120000_add_dm_keyword_trigger/migration.sql
+++ b/prisma/migrations/20260731120000_add_dm_keyword_trigger/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Automation" ADD COLUMN     "dmTriggerEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,6 +178,10 @@ model Automation {
   matchAnyPost   Boolean @default(false)
   keywords       String[]
   matchAnyWord   Boolean @default(false)
+  // Also fire this campaign when someone sends a DM whose text matches the
+  // keywords above. Independent of the post trigger — a DM has no media, so
+  // postId / matchAnyPost do not apply to it.
+  dmTriggerEnabled Boolean @default(false)
   dmMessage      String
   openingDmEnabled     Boolean @default(false)
   openingDmMessage     String?


### PR DESCRIPTION
## What

A campaign can now fire on inbound DMs as well as comments. Turning on **"also reply when someone DMs these words"** makes the worker answer any DM whose text matches the campaign's keywords with the same reveal message.

The motivation: people who see a reel often skip the comment and just DM the keyword directly. Today that goes unanswered.

Story replies come through too — Instagram delivers them via the same `messages` field as an ordinary message with text.

## How

- **`parseMessageEvents`** (`lib/meta/webhook.ts`) — `subscribed_fields` already included `messages`; only the parser was missing. Echoes are dropped, which matters here: without that, an autoreply whose text contains its own keyword would trigger itself. Deletions, unsupported messages, and attachment-only messages with no text are dropped too.
- **`processMessage`** (`lib/queue/dm-worker.ts`) — new `process-message` job. Dedup is per inbound message id (`DmLog.commentId` = `dm:<mid>`), so a job retry never double-sends.
- **`Automation.dmTriggerEnabled`** — additive column, defaults `false`, so existing campaigns are untouched.
- Builder toggle plus a conditional **DM trigger** preview tab.

## Two decisions worth reviewing

**The opening DM is skipped on this path.** It exists to work around the one-private-reply-per-comment limit — the button tap is what opens a messaging window. A user who DMs you has already opened that window, so the button buys nothing and costs a send plus a drop-off point. The follow gate *is* preserved, because its button does real work (re-verifying the follow).

**The follow-up fires here too.** A DM-triggered link delivery is the same "link delivered" moment as a button tap, so it schedules the appreciation follow-up identically — but only on the reveal branch, not behind the follow prompt, where no link has gone out yet.

Both are judgement calls; happy to change either.

## Refactor

`processPostback` and `processMessage` both send a reveal into an already-open conversation, so the button-template-with-inline-link-fallback logic is now one shared `sendRevealDirectMessage`. This keeps the `isTemplateRejection` guard from 99600c2 in a single place rather than duplicated. `processComment` is untouched — it still uses the private-reply variants.

## Not included

- Story replies aren't distinguishable from DMs in the log and can't be given their own message. That needs `reply_to.story` plumbed through plus another campaign field, which felt like a separate change.
- No per-user cooldown: five DMs in a row get five replies, since each is a distinct message id. Easy to add if you'd want it.

## Checks

All four from CONTRIBUTING pass on this branch:

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 132 passed, including 16 new (parser: echoes, deletions, attachment-only, self-sends, non-instagram payloads; worker: match, no-match, dedup, tracked-link buttons, follow gate both ways, plan limit, send failure)
- `npm run build` — clean

Not verified against live Instagram traffic for the story-reply case specifically — that claim is based on the payload shape, not an observed webhook.