### PR TITLE
docs: fix incorrect Twitter/X profile link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Built and maintained by Diwen Huang.
 
 - GitHub: [@diwenne](https://github.com/diwenne)
 - Website: [diwenhuang.ca](https://diwenhuang.ca)
-- X: [@diwenne](https://x.com/diwenne)
+- X: [@diwenne](https://x.com/diwennee)
 - Instagram: [@devdiwen](https://instagram.com/devdiwen)
 
 OpenReply is a fork of [instagram-comment-to-dm](https://github.com/im-anishraj/instagram-comment-to-dm) by [Anish Raj](https://github.com/im-anishraj), also MIT licensed. The billing layer and plan caps were removed, and the setup was documented from scratch.


### PR DESCRIPTION
Updated the incorrect Twitter/X profile link in the README to the correct URL :)