### PR TITLE
feat: internal lint-copy + campaign-stats endpoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git
+.github
+.next
+.vercel
+coverage
+node_modules
+npm-debug.log*
+.env*
+!.env.example
+docs
+deploy

--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,12 @@ AUTH_ALLOWED_DOMAINS=
 # Single-organization mode: new allowed users join the oldest existing
 # workspace as MEMBER instead of creating their own empty one.
 AUTH_JOIN_EXISTING_WORKSPACE=false
+
+# Release-to-campaign sync (optional). The shop-side feed is
+# GET <site>/wp-json/yoyaku/v1/release-events. Campaigns are created inactive
+# unless RELEASE_SYNC_AUTO_ACTIVATE=true.
+RELEASE_SYNC_ENABLED=false
+RELEASE_EVENTS_URL=
+RELEASE_EVENTS_KEY=
+RELEASE_SYNC_IG_USERNAME=yoyakurecordstore
+RELEASE_SYNC_AUTO_ACTIVATE=false

--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,15 @@ INSTAGRAM_APP_ID=your-instagram-app-id
 INSTAGRAM_APP_SECRET=your-instagram-app-secret
 FACEBOOK_APP_SECRET=your-facebook-app-secret
 WEBHOOK_VERIFY_TOKEN=replace-with-a-webhook-verify-token
+
+# Google sign-in (optional). Create an OAuth client in Google Cloud Console
+# with redirect URI <NEXTAUTH_URL>/api/auth/callback/google. Leaving these
+# empty hides the Google button and keeps magic-link login only.
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+# Optional domain allowlist, combined with AUTH_ALLOWED_EMAILS (either match
+# grants access). Example: yoyaku.fr,interwave.live
+AUTH_ALLOWED_DOMAINS=
+# Single-organization mode: new allowed users join the oldest existing
+# workspace as MEMBER instead of creating their own empty one.
+AUTH_JOIN_EXISTING_WORKSPACE=false

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ REDIS_URL=redis://localhost:6379
 # Email magic links (Resend)
 RESEND_API_KEY=re_...
 EMAIL_FROM=OpenReply <login@example.com>
+# Optional self-hosting guard. When set, only these comma-separated addresses
+# can request a magic link. Leave empty to preserve public signup behavior.
+AUTH_ALLOWED_EMAILS=
 
 # Meta / Instagram
 META_GRAPH_API_VERSION=v25.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,14 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev
 
       - name: Generate Prisma client
         run: npm run db:generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: npm ci
 
       - name: Audit production dependencies
-        run: npm audit --omit=dev
+        run: npm audit --omit=dev --audit-level=high
 
       - name: Generate Prisma client
         run: npm run db:generate

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ FROM base AS dependencies
 COPY package.json package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm npm ci
 
+FROM base AS production-dependencies
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci --omit=dev
+
 FROM dependencies AS builder
 COPY . .
 
@@ -50,7 +54,7 @@ ENV NODE_ENV=production
 RUN groupadd --system --gid 1001 openreply \
     && useradd --system --uid 1001 --gid openreply --home-dir /app openreply
 
-COPY --from=dependencies --chown=openreply:openreply /app/node_modules ./node_modules
+COPY --from=production-dependencies --chown=openreply:openreply /app/node_modules ./node_modules
 COPY --chown=openreply:openreply . .
 COPY --from=builder --chown=openreply:openreply /app/app/generated ./app/generated
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1.7
+
+FROM node:22.22.0-bookworm-slim AS base
+ENV NEXT_TELEMETRY_DISABLED=1
+WORKDIR /app
+
+FROM base AS dependencies
+COPY package.json package-lock.json ./
+RUN --mount=type=cache,target=/root/.npm npm ci
+
+FROM dependencies AS builder
+COPY . .
+
+# These build-only placeholders are never copied into the runtime environment.
+# Server-side OpenReply configuration is read from the container environment.
+ENV NEXTAUTH_URL=http://127.0.0.1:3000 \
+    NEXTAUTH_SECRET=build-only-nextauth-secret \
+    CRON_SECRET=build-only-cron-secret \
+    ENCRYPTION_KEY=0000000000000000000000000000000000000000000000000000000000000000 \
+    DATABASE_URL=postgresql://openreply:build-only@127.0.0.1:5432/openreply \
+    REDIS_URL=redis://127.0.0.1:6379 \
+    INSTAGRAM_APP_ID=build-only \
+    INSTAGRAM_APP_SECRET=build-only \
+    FACEBOOK_APP_SECRET=build-only \
+    WEBHOOK_VERIFY_TOKEN=build-only
+RUN npm run build
+
+FROM base AS web
+ENV NODE_ENV=production \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+
+RUN groupadd --system --gid 1001 openreply \
+    && useradd --system --uid 1001 --gid openreply --home-dir /app openreply
+
+COPY --from=builder --chown=openreply:openreply /app/.next/standalone ./
+COPY --from=builder --chown=openreply:openreply /app/.next/static ./.next/static
+COPY --from=builder --chown=openreply:openreply /app/public ./public
+
+USER openreply
+EXPOSE 3000
+CMD ["node", "server.js"]
+
+FROM base AS worker
+ENV NODE_ENV=production
+
+RUN groupadd --system --gid 1001 openreply \
+    && useradd --system --uid 1001 --gid openreply --home-dir /app openreply
+
+COPY --from=dependencies --chown=openreply:openreply /app/node_modules ./node_modules
+COPY --chown=openreply:openreply . .
+COPY --from=builder --chown=openreply:openreply /app/app/generated ./app/generated
+
+USER openreply
+CMD ["npm", "run", "worker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 FROM node:22.22.0-bookworm-slim AS base
 ENV NEXT_TELEMETRY_DISABLED=1
 WORKDIR /app
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates openssl \
+    && apt-get clean
 
 FROM base AS dependencies
 COPY package.json package-lock.json ./

--- a/__tests__/auth-allowlist.test.ts
+++ b/__tests__/auth-allowlist.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  isAuthDomainAllowed,
   isAuthEmailAllowed,
+  isAuthSignInAllowed,
+  parseAuthDomainAllowlist,
   parseAuthEmailAllowlist,
 } from "@/lib/auth-allowlist";
 
@@ -35,5 +38,72 @@ describe("authentication email allowlist", () => {
   it("fails closed when a configured allowlist contains only separators or whitespace", () => {
     expect(isAuthEmailAllowed("stranger@example.com", "  ")).toBe(false);
     expect(isAuthEmailAllowed("stranger@example.com", " , ")).toBe(false);
+  });
+});
+
+describe("authentication domain allowlist", () => {
+  it("normalizes domains and strips leading @", () => {
+    expect(parseAuthDomainAllowlist(" @Yoyaku.FR, interwave.live ")).toEqual(
+      new Set(["yoyaku.fr", "interwave.live"])
+    );
+  });
+
+  it("preserves public signup when no domain list is configured", () => {
+    expect(isAuthDomainAllowed("person@example.com")).toBe(true);
+    expect(isAuthDomainAllowed(null, "")).toBe(true);
+  });
+
+  it("allows configured domains case-insensitively", () => {
+    expect(isAuthDomainAllowed("Ben@YOYAKU.fr", "yoyaku.fr,interwave.live")).toBe(
+      true
+    );
+    expect(
+      isAuthDomainAllowed("tracy@interwave.live", "yoyaku.fr,interwave.live")
+    ).toBe(true);
+  });
+
+  it("rejects other domains, subdomains, and malformed emails", () => {
+    expect(isAuthDomainAllowed("someone@gmail.com", "yoyaku.fr")).toBe(false);
+    expect(isAuthDomainAllowed("someone@mail.yoyaku.fr", "yoyaku.fr")).toBe(false);
+    expect(isAuthDomainAllowed("not-an-email", "yoyaku.fr")).toBe(false);
+    expect(isAuthDomainAllowed(null, "yoyaku.fr")).toBe(false);
+  });
+
+  it("fails closed on a whitespace-only configured value", () => {
+    expect(isAuthDomainAllowed("ben@yoyaku.fr", " , ")).toBe(false);
+  });
+});
+
+describe("combined sign-in gate", () => {
+  it("keeps public signup with neither list configured", () => {
+    expect(isAuthSignInAllowed("anyone@anywhere.com")).toBe(true);
+    expect(isAuthSignInAllowed("anyone@anywhere.com", "", "")).toBe(true);
+  });
+
+  it("grants access on a domain match alone", () => {
+    expect(
+      isAuthSignInAllowed("nizar@yoyaku.fr", "b@yoyaku.fr", "yoyaku.fr,interwave.live")
+    ).toBe(true);
+  });
+
+  it("grants access on an explicit address even outside allowed domains", () => {
+    expect(
+      isAuthSignInAllowed("freelance@gmail.com", "freelance@gmail.com", "yoyaku.fr")
+    ).toBe(true);
+  });
+
+  it("rejects when neither list matches", () => {
+    expect(
+      isAuthSignInAllowed("stranger@gmail.com", "b@yoyaku.fr", "yoyaku.fr")
+    ).toBe(false);
+  });
+
+  it("keeps the email-only configuration backward compatible", () => {
+    expect(isAuthSignInAllowed("b@yoyaku.fr", "b@yoyaku.fr")).toBe(true);
+    expect(isAuthSignInAllowed("x@yoyaku.fr", "b@yoyaku.fr")).toBe(false);
+  });
+
+  it("rejects a missing email once any list is configured", () => {
+    expect(isAuthSignInAllowed(null, "b@yoyaku.fr", "yoyaku.fr")).toBe(false);
   });
 });

--- a/__tests__/auth-allowlist.test.ts
+++ b/__tests__/auth-allowlist.test.ts
@@ -31,4 +31,9 @@ describe("authentication email allowlist", () => {
     ).toBe(false);
     expect(isAuthEmailAllowed(null, "owner@example.com")).toBe(false);
   });
+
+  it("fails closed when a configured allowlist contains only separators or whitespace", () => {
+    expect(isAuthEmailAllowed("stranger@example.com", "  ")).toBe(false);
+    expect(isAuthEmailAllowed("stranger@example.com", " , ")).toBe(false);
+  });
 });

--- a/__tests__/auth-allowlist.test.ts
+++ b/__tests__/auth-allowlist.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAuthEmailAllowed,
+  parseAuthEmailAllowlist,
+} from "@/lib/auth-allowlist";
+
+describe("authentication email allowlist", () => {
+  it("preserves public signup when no allowlist is configured", () => {
+    expect(isAuthEmailAllowed("person@example.com")).toBe(true);
+    expect(isAuthEmailAllowed(null, "")).toBe(true);
+  });
+
+  it("normalizes configured addresses", () => {
+    expect(
+      parseAuthEmailAllowlist(" Owner@Example.com, member@example.com ")
+    ).toEqual(new Set(["owner@example.com", "member@example.com"]));
+  });
+
+  it("allows configured addresses case-insensitively", () => {
+    expect(
+      isAuthEmailAllowed(
+        "OWNER@example.com",
+        "owner@example.com,member@example.com"
+      )
+    ).toBe(true);
+  });
+
+  it("rejects unconfigured and missing addresses", () => {
+    expect(
+      isAuthEmailAllowed("stranger@example.com", "owner@example.com")
+    ).toBe(false);
+    expect(isAuthEmailAllowed(null, "owner@example.com")).toBe(false);
+  });
+});

--- a/__tests__/internal-api.test.ts
+++ b/__tests__/internal-api.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    automation: { findFirst: vi.fn() },
+    dmLog: { count: vi.fn() },
+    linkClick: { count: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db/client", () => ({ prisma: mockPrisma }));
+
+import { POST as lintCopy } from "@/app/api/internal/lint-copy/route";
+import { GET as campaignStats } from "@/app/api/internal/campaign-stats/route";
+import { NextRequest } from "next/server";
+
+const SECRET = "test-secret";
+
+function lintRequest(body: unknown, auth: string | null = `Bearer ${SECRET}`) {
+  return new NextRequest("http://localhost/api/internal/lint-copy", {
+    method: "POST",
+    headers: auth ? { authorization: auth } : {},
+    body: JSON.stringify(body),
+  });
+}
+
+function statsRequest(query: string, auth: string | null = `Bearer ${SECRET}`) {
+  return new NextRequest(`http://localhost/api/internal/campaign-stats${query}`, {
+    headers: auth ? { authorization: auth } : {},
+  });
+}
+
+beforeEach(() => {
+  process.env.CRON_SECRET = SECRET;
+  vi.clearAllMocks();
+});
+
+describe("POST /api/internal/lint-copy", () => {
+  it("rejects a missing or wrong bearer", async () => {
+    expect((await lintCopy(lintRequest({ text: "x" }, null))).status).toBe(401);
+    expect((await lintCopy(lintRequest({ text: "x" }, "Bearer nope"))).status).toBe(401);
+  });
+
+  it("flags style violations on a ManyChat-style caption", async () => {
+    const res = await lintCopy(
+      lintRequest({ text: "Hey! 🌟 Dive into this fresh perspective!" })
+    );
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.data.ok).toBe(false);
+    const rules = json.data.violations.map((v: { rule: string }) => v.rule);
+    expect(rules).toContain("no-emoji");
+    expect(rules).toContain("cliche");
+  });
+
+  it("does not flag proper nouns when no fact block is supplied", async () => {
+    const res = await lintCopy(
+      lintRequest({ text: "Aleksi Perala, Cycles. Preorder is open on Trip." })
+    );
+    const json = await res.json();
+    expect(json.data.ok).toBe(true);
+  });
+
+  it("still enforces the noun rule when nouns are supplied", async () => {
+    const res = await lintCopy(
+      lintRequest({ text: "Out now on Rekids.", nouns: ["Trip"] })
+    );
+    const json = await res.json();
+    expect(json.data.ok).toBe(false);
+    expect(json.data.violations.some((v: { rule: string }) => v.rule === "invented-noun")).toBe(true);
+  });
+});
+
+describe("GET /api/internal/campaign-stats", () => {
+  it("rejects a missing bearer and a missing sku", async () => {
+    expect((await campaignStats(statsRequest("?sku=X", null))).status).toBe(401);
+    expect((await campaignStats(statsRequest(""))).status).toBe(400);
+  });
+
+  it("returns null when no campaign matches the catno", async () => {
+    mockPrisma.automation.findFirst.mockResolvedValue(null);
+    const res = await campaignStats(statsRequest("?sku=NOPE1"));
+    const json = await res.json();
+    expect(json.data.automation).toBeNull();
+    expect(mockPrisma.automation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { catnoTag: { equals: "NOPE1", mode: "insensitive" } },
+      })
+    );
+  });
+
+  it("returns the newest matching campaign with SENT + click counts", async () => {
+    mockPrisma.automation.findFirst.mockResolvedValue({
+      id: "a1", name: "HCLP008", isActive: true, postId: "p1", createdAt: new Date(0),
+    });
+    mockPrisma.dmLog.count.mockResolvedValue(37);
+    mockPrisma.linkClick.count.mockResolvedValue(35);
+    const res = await campaignStats(statsRequest("?sku=hclp008"));
+    const json = await res.json();
+    expect(json.data.automation).toMatchObject({ id: "a1", dmSent: 37, clicks: 35 });
+    expect(mockPrisma.dmLog.count).toHaveBeenCalledWith({
+      where: { automationId: "a1", status: "SENT" },
+    });
+  });
+});

--- a/__tests__/release-sync.test.ts
+++ b/__tests__/release-sync.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  captionMatchesCatno,
+  deriveInstoreEvents,
+  deriveReleaseEvents,
+  instoreDedupKey,
+  type ShopProduct,
+} from "@/lib/release-sync/shop-feed";
+
+function product(overrides: Partial<ShopProduct>): ShopProduct {
+  return {
+    sku: "TO001",
+    artist: "Theo Kottis",
+    label: "Yoyaku",
+    title: "Pressure EP",
+    url: "https://yoyaku.io/release/theo-kottis-pressure-ep-to001/",
+    stock_status: "onbackorder",
+    is_preorder: true,
+    published_gmt: "2026-08-01T10:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("release event derivation", () => {
+  it("derives preorder_open for an unseen preorder", () => {
+    const events = deriveReleaseEvents([product({})], new Map());
+    expect(events).toHaveLength(1);
+    expect(events[0].facts.eventType).toBe("preorder_open");
+    expect(events[0].sku).toBe("TO001");
+  });
+
+  it("derives release_live on the preorder-to-stock flip", () => {
+    const events = deriveReleaseEvents(
+      [product({ stock_status: "instock" })],
+      new Map([["TO001", "onbackorder"]])
+    );
+    expect(events[0].facts.eventType).toBe("release_live");
+  });
+
+  it("derives restock on the out-of-stock-to-stock flip", () => {
+    const events = deriveReleaseEvents(
+      [product({ stock_status: "instock" })],
+      new Map([["TO001", "outofstock"]])
+    );
+    expect(events[0].facts.eventType).toBe("restock");
+  });
+
+  it("derives release_live for an unseen product already in stock", () => {
+    const events = deriveReleaseEvents(
+      [product({ stock_status: "instock" })],
+      new Map()
+    );
+    expect(events[0].facts.eventType).toBe("release_live");
+  });
+
+  it("derives nothing for unchanged status or stock-out transitions", () => {
+    expect(
+      deriveReleaseEvents([product({})], new Map([["TO001", "onbackorder"]]))
+    ).toEqual([]);
+    expect(
+      deriveReleaseEvents(
+        [product({ stock_status: "outofstock" })],
+        new Map([["TO001", "instock"]])
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("instore event derivation", () => {
+  it("keys events on the artist and falls back to the shop SoundCloud", () => {
+    const events = deriveInstoreEvents([
+      {
+        artist: "Didier Allyne",
+        youtube_url: "https://youtu.be/x",
+        soundcloud_url: "",
+        published_gmt: "2026-08-01T10:00:00Z",
+      },
+    ]);
+    expect(events[0].sku).toBe(instoreDedupKey("Didier Allyne"));
+    expect(events[0].facts).toMatchObject({
+      eventType: "instore_published",
+      soundcloudUrl: "https://soundcloud.com/yoyaku",
+    });
+  });
+});
+
+describe("caption catno matching", () => {
+  it("matches the hashtag case-insensitively anywhere in the caption", () => {
+    expect(captionMatchesCatno("Out friday. #to001 preorder in bio", "TO001")).toBe(
+      true
+    );
+    expect(
+      captionMatchesCatno("New one from Theo Kottis #TO001", "TO001")
+    ).toBe(true);
+  });
+
+  it("does not match a longer catno sharing the prefix", () => {
+    expect(captionMatchesCatno("#TO0011 out now", "TO001")).toBe(false);
+    expect(captionMatchesCatno("#GETTRAUM017", "GETTRAUM01")).toBe(false);
+  });
+
+  it("requires the hashtag form and a caption", () => {
+    expect(captionMatchesCatno("TO001 without hash", "TO001")).toBe(false);
+    expect(captionMatchesCatno(undefined, "TO001")).toBe(false);
+  });
+});

--- a/__tests__/workspace-join.test.ts
+++ b/__tests__/workspace-join.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    workspaceInvitation: { findMany: vi.fn() },
+    workspaceMember: { findFirst: vi.fn(), upsert: vi.fn() },
+    workspace: { findFirst: vi.fn(), create: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/db/client", () => ({ prisma: mockPrisma }));
+
+import { ensureWorkspaceForUser } from "../lib/workspace";
+
+const OLDEST = { id: "ws_oldest", name: "b's workspace", ownerId: "user_b" };
+
+describe("single-organization workspace join", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockPrisma.workspaceInvitation.findMany.mockResolvedValue([]);
+    mockPrisma.workspaceMember.findFirst.mockResolvedValue(null);
+    mockPrisma.workspaceMember.upsert.mockResolvedValue({});
+    mockPrisma.workspace.create.mockImplementation(
+      async ({ data }: { data: { name: string } }) => ({
+        id: "ws_new",
+        name: data.name,
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("joins the oldest workspace as MEMBER when the mode is enabled", async () => {
+    vi.stubEnv("AUTH_JOIN_EXISTING_WORKSPACE", "true");
+    mockPrisma.workspace.findFirst.mockResolvedValue(OLDEST);
+
+    const workspace = await ensureWorkspaceForUser("user_anna", "anna@yoyaku.fr");
+
+    expect(workspace.id).toBe("ws_oldest");
+    expect(mockPrisma.workspaceMember.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ role: "MEMBER", userId: "user_anna" }),
+      })
+    );
+    expect(mockPrisma.workspace.create).not.toHaveBeenCalled();
+  });
+
+  it("still creates an OWNER workspace for the very first user", async () => {
+    vi.stubEnv("AUTH_JOIN_EXISTING_WORKSPACE", "true");
+    mockPrisma.workspace.findFirst.mockResolvedValue(null);
+
+    const workspace = await ensureWorkspaceForUser("user_first", "b@yoyaku.fr");
+
+    expect(workspace.id).toBe("ws_new");
+    expect(mockPrisma.workspace.create).toHaveBeenCalled();
+  });
+
+  it("keeps the upstream own-workspace behavior when the mode is off", async () => {
+    vi.stubEnv("AUTH_JOIN_EXISTING_WORKSPACE", "false");
+
+    const workspace = await ensureWorkspaceForUser("user_solo", "solo@yoyaku.fr");
+
+    expect(workspace.id).toBe("ws_new");
+    expect(mockPrisma.workspace.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("prefers an existing membership over joining", async () => {
+    vi.stubEnv("AUTH_JOIN_EXISTING_WORKSPACE", "true");
+    mockPrisma.workspaceMember.findFirst.mockResolvedValue({
+      workspace: { id: "ws_mine" },
+      role: "ADMIN",
+    });
+
+    const workspace = await ensureWorkspaceForUser("user_known", "known@yoyaku.fr");
+
+    expect(workspace.id).toBe("ws_mine");
+    expect(mockPrisma.workspaceMember.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/yoyaku-copy.test.ts
+++ b/__tests__/yoyaku-copy.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCampaignCopy,
+  META_BODY_LIMIT,
+  META_BUTTON_LIMIT,
+} from "@/lib/copy/yoyaku-patterns";
+import { lintCampaignCopy, lintText } from "@/lib/copy/copy-linter";
+import { factNouns, missingFacts } from "@/lib/copy/release-facts";
+import type { InstoreFacts, ReleaseFacts } from "@/lib/copy/release-facts";
+
+const RELEASE: ReleaseFacts = {
+  eventType: "preorder_open",
+  artist: "Theo Kottis",
+  title: "Pressure EP",
+  catno: "TO001",
+  label: "Yoyaku",
+  url: "https://yoyaku.io/release/theo-kottis-pressure-ep-to001/",
+};
+
+const INSTORE: InstoreFacts = {
+  eventType: "instore_published",
+  artist: "Didier Allyne",
+  youtubeUrl: "https://youtu.be/dBGjgTg5_DM",
+  soundcloudUrl: "https://soundcloud.com/yoyaku",
+};
+
+describe("release facts", () => {
+  it("flags missing fields instead of inventing them", () => {
+    expect(missingFacts({ ...RELEASE, label: " " })).toEqual(["label"]);
+    expect(missingFacts(RELEASE)).toEqual([]);
+    expect(missingFacts({ ...INSTORE, youtubeUrl: "" })).toEqual(["youtubeUrl"]);
+  });
+});
+
+describe("yoyaku patterns", () => {
+  const eventTypes = ["preorder_open", "release_live", "restock"] as const;
+
+  it.each(eventTypes)("%s copy passes the linter", (eventType) => {
+    const facts = { ...RELEASE, eventType };
+    const copy = buildCampaignCopy(facts);
+    const result = lintCampaignCopy(copy, facts);
+    expect(result.violations).toEqual([]);
+    expect(copy.openingDmMessage.length).toBeLessThanOrEqual(META_BODY_LIMIT);
+    expect(copy.linkButtonLabel.length).toBeLessThanOrEqual(META_BUTTON_LIMIT);
+    expect(copy.trackedDestinationUrl).toBe(RELEASE.url);
+  });
+
+  it("instore copy passes and carries both platform links", () => {
+    const copy = buildCampaignCopy(INSTORE);
+    expect(lintCampaignCopy(copy, INSTORE).violations).toEqual([]);
+    expect(copy.trackedDestinationUrl).toBe(INSTORE.youtubeUrl);
+    expect(copy.secondaryDestinationUrl).toBe(INSTORE.soundcloudUrl);
+    expect(copy.secondaryButtonLabel).toBe("SoundCloud");
+  });
+
+  it("is deterministic for the same release", () => {
+    expect(buildCampaignCopy(RELEASE)).toEqual(buildCampaignCopy(RELEASE));
+  });
+
+  it("keeps the preorder button inside Meta's 20-char limit", () => {
+    const short = buildCampaignCopy(RELEASE);
+    expect(short.linkButtonLabel).toBe("Preorder TO001");
+
+    const long = buildCampaignCopy({ ...RELEASE, catno: "STICKYPLASTICK002" });
+    expect(long.linkButtonLabel.length).toBeLessThanOrEqual(META_BUTTON_LIMIT);
+    expect(long.linkButtonLabel).toContain("STICKYPLASTICK");
+  });
+});
+
+describe("copy linter — the real ManyChat copy is rejected", () => {
+  const nouns = factNouns(RELEASE);
+
+  const manychatSamples: Array<[string, string]> = [
+    ["Hey! Amor Fati is here with Dj Strangelove upcoming release 🌟", "no-hey-opening"],
+    ["Dive into Studio HC Orchestra's world 🌊", "cliche"],
+    [
+      "Theo Kottis with his fresh perspective of the classics on the wax. Wanna hear it?",
+      "cliche",
+    ],
+    [
+      "Looking for some stripped minimal sounds, deep textures, and hypnotic grooves? You're in the right place",
+      "adjective-triad",
+    ],
+    ["ZZZ Series is coming out with the third release on vinyl 🖤 Let's listen?", "no-emoji"],
+  ];
+
+  it.each(manychatSamples)("rejects: %s", (text, expectedRule) => {
+    const violations = lintText(text, nouns);
+    expect(violations.length).toBeGreaterThan(0);
+    expect(violations.map((v) => v.rule)).toContain(expectedRule);
+  });
+
+  it("rejects every emoji, not just the second one", () => {
+    expect(lintText("Preorder is open 🎶", nouns).map((v) => v.rule)).toContain(
+      "no-emoji"
+    );
+  });
+
+  it("rejects em and en dashes", () => {
+    expect(lintText("Theo Kottis — Pressure EP", nouns).map((v) => v.rule)).toContain(
+      "no-dashes"
+    );
+  });
+
+  it("rejects proper nouns that are not in the fact block", () => {
+    const violations = lintText("Pressure EP by Ricardo Villalobos.", nouns);
+    const invented = violations.find((v) => v.rule === "invented-noun");
+    expect(invented).toBeDefined();
+    expect(invented?.detail).toContain("Ricardo");
+  });
+
+  it("accepts fact nouns and shell vocabulary", () => {
+    expect(
+      lintText("Theo Kottis, Pressure EP. Preorder is open on Yoyaku.", nouns)
+    ).toEqual([]);
+  });
+
+  it("rejects oversize fields via the campaign-level lint", () => {
+    const copy = buildCampaignCopy(RELEASE);
+    const result = lintCampaignCopy(
+      { ...copy, openingDmButtonLabel: "A far too long button label" },
+      RELEASE
+    );
+    expect(result.ok).toBe(false);
+    expect(result.violations.map((v) => v.rule)).toContain("meta-button-limit");
+  });
+});

--- a/app/api/cron/attach-next-reel/route.ts
+++ b/app/api/cron/attach-next-reel/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/db/client";
 import { getUserMedia, type InstagramMedia } from "@/lib/meta/client";
 import { decryptToken } from "@/lib/meta/oauth";
+import { captionMatchesCatno } from "@/lib/release-sync/shop-feed";
 
 /**
  * Binds "next reel" campaigns to a real post.
@@ -54,6 +55,7 @@ export async function GET(request: NextRequest) {
     if (!account?.accessToken) continue;
 
     let reels: InstagramMedia[];
+    let allMedia: InstagramMedia[];
     try {
       const token = decryptToken(account.accessToken);
       const media = await getUserMedia(token, 25);
@@ -63,6 +65,10 @@ export async function GET(request: NextRequest) {
           (a, b) =>
             new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
         );
+      allMedia = [...media].sort(
+        (a, b) =>
+          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      );
     } catch (err) {
       failures.push(account.id);
       console.error("[attach-next-reel] media fetch failed", account.id, err);
@@ -70,17 +76,28 @@ export async function GET(request: NextRequest) {
     }
 
     for (const automation of automations) {
+      // Deterministic binding first: a campaign carrying a catno binds to the
+      // earliest media (any type, square posts included) whose caption
+      // contains #<catno>. Without a match it falls back to next-reel.
+      const catnoMedia = automation.catnoTag
+        ? allMedia.find(
+            (m) =>
+              new Date(m.timestamp) > automation.createdAt &&
+              captionMatchesCatno(m.caption, automation.catnoTag as string)
+          )
+        : undefined;
+
       // The "next" reel = the earliest one posted after the campaign was created.
-      const nextReel = reels.find(
-        (reel) => new Date(reel.timestamp) > automation.createdAt
-      );
-      if (!nextReel) continue;
+      const target =
+        catnoMedia ??
+        reels.find((reel) => new Date(reel.timestamp) > automation.createdAt);
+      if (!target) continue;
 
       await prisma.automation.update({
         where: { id: automation.id },
         data: {
-          postId: nextReel.id,
-          postUrl: nextReel.permalink ?? null,
+          postId: target.id,
+          postUrl: target.permalink ?? null,
           pendingNextReel: false,
         },
       });

--- a/app/api/cron/sync-releases/route.ts
+++ b/app/api/cron/sync-releases/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db/client";
+import {
+  deriveInstoreEvents,
+  deriveReleaseEvents,
+  type DerivedEvent,
+  type ShopFeed,
+} from "@/lib/release-sync/shop-feed";
+import { buildCampaignCopy } from "@/lib/copy/yoyaku-patterns";
+import { lintCampaignCopy } from "@/lib/copy/copy-linter";
+import { missingFacts } from "@/lib/copy/release-facts";
+import { createGeneratedCampaign } from "@/lib/automations/create-generated";
+
+/**
+ * Release-to-campaign sync.
+ *
+ * Pulls the shop's release feed (new exclusive preorders, releases going
+ * live, restocks, published instore sessions), derives typed events by
+ * diffing stock statuses against the last seen state, and turns each fresh
+ * event into an INACTIVE campaign built from the hand-written YOYAKU
+ * patterns. Guardrails: RELEASE_SYNC_ENABLED kill switch (default off),
+ * MAX_CAMPAIGNS_PER_RUN cap, structural idempotence via the
+ * (sku, eventType) unique in ReleaseSyncEvent, and the copy linter as a
+ * hard gate — rejected copy never becomes a campaign.
+ */
+
+const MAX_CAMPAIGNS_PER_RUN = 5;
+
+async function recordOutcome(
+  event: DerivedEvent,
+  outcome: string,
+  detail: string | null,
+  automationId: string | null
+) {
+  await prisma.releaseSyncEvent.create({
+    data: {
+      sku: event.sku,
+      eventType: event.facts.eventType,
+      outcome,
+      detail,
+      automationId,
+    },
+  });
+}
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET || process.env.NEXTAUTH_SECRET;
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  if (process.env.RELEASE_SYNC_ENABLED !== "true") {
+    return NextResponse.json({
+      success: true,
+      data: { enabled: false, created: 0 },
+    });
+  }
+
+  const feedUrl = process.env.RELEASE_EVENTS_URL;
+  const feedKey = process.env.RELEASE_EVENTS_KEY;
+  if (!feedUrl || !feedKey) {
+    return NextResponse.json(
+      { success: false, error: "RELEASE_EVENTS_URL / RELEASE_EVENTS_KEY not configured" },
+      { status: 500 }
+    );
+  }
+
+  const username = process.env.RELEASE_SYNC_IG_USERNAME ?? "yoyakurecordstore";
+  const account = await prisma.instagramAccount.findFirst({
+    where: { username },
+    select: { id: true, workspaceId: true },
+  });
+  if (!account) {
+    return NextResponse.json(
+      { success: false, error: `Instagram account ${username} is not connected` },
+      { status: 500 }
+    );
+  }
+
+  let feed: ShopFeed;
+  try {
+    const response = await fetch(`${feedUrl}?key=${encodeURIComponent(feedKey)}`, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(20_000),
+    });
+    if (!response.ok) {
+      throw new Error(`feed responded ${response.status}`);
+    }
+    feed = (await response.json()) as ShopFeed;
+  } catch (err) {
+    console.error("[sync-releases] feed fetch failed", err);
+    return NextResponse.json(
+      { success: false, error: "Release feed unreachable" },
+      { status: 502 }
+    );
+  }
+
+  const products = Array.isArray(feed.products) ? feed.products : [];
+  const instore = Array.isArray(feed.instore) ? feed.instore : [];
+
+  const knownStates = await prisma.releaseProductState.findMany({
+    where: { sku: { in: products.map((p) => p.sku) } },
+  });
+  const lastStatusBySku = new Map(knownStates.map((s) => [s.sku, s.lastStatus]));
+
+  const events = [
+    ...deriveReleaseEvents(products, lastStatusBySku),
+    ...deriveInstoreEvents(instore),
+  ];
+
+  let created = 0;
+  let skipped = 0;
+  let rejected = 0;
+
+  for (const event of events) {
+    if (created >= MAX_CAMPAIGNS_PER_RUN) break;
+
+    const alreadyProcessed = await prisma.releaseSyncEvent.findUnique({
+      where: {
+        sku_eventType: { sku: event.sku, eventType: event.facts.eventType },
+      },
+    });
+    if (alreadyProcessed) {
+      skipped += 1;
+      continue;
+    }
+
+    const missing = missingFacts(event.facts);
+    if (missing.length > 0) {
+      await recordOutcome(event, "incomplete", `missing: ${missing.join(", ")}`, null);
+      rejected += 1;
+      continue;
+    }
+
+    const copy = buildCampaignCopy(event.facts);
+    const lint = lintCampaignCopy(copy, event.facts);
+    if (!lint.ok) {
+      await recordOutcome(
+        event,
+        "lint_rejected",
+        lint.violations.map((v) => `${v.rule}: ${v.detail}`).join(" | "),
+        null
+      );
+      rejected += 1;
+      continue;
+    }
+
+    const automation = await createGeneratedCampaign({
+      copy,
+      catnoTag:
+        event.facts.eventType === "instore_published" ? null : event.facts.catno,
+      workspaceId: account.workspaceId,
+      instagramAccountId: account.id,
+      isActive: process.env.RELEASE_SYNC_AUTO_ACTIVATE === "true",
+    });
+
+    await recordOutcome(event, "created", null, automation.id);
+    created += 1;
+  }
+
+  // Persist the freshly observed statuses so the next run diffs against them.
+  for (const product of products) {
+    await prisma.releaseProductState.upsert({
+      where: { sku: product.sku },
+      create: { sku: product.sku, lastStatus: product.stock_status },
+      update: { lastStatus: product.stock_status },
+    });
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      enabled: true,
+      products: products.length,
+      instore: instore.length,
+      events: events.length,
+      created,
+      skipped,
+      rejected,
+    },
+  });
+}

--- a/app/api/internal/campaign-stats/route.ts
+++ b/app/api/internal/campaign-stats/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db/client";
+
+/**
+ * Internal campaign-stats endpoint — lets sibling services on this host (the
+ * label-platform marketing calendar) show, per SKU, whether an OpenReply
+ * campaign exists and how it performs.
+ *
+ * GET ?sku=<catno> → { automation: {id, name, isActive, postId, dmSent,
+ * clicks, createdAt} | null }
+ *
+ * Matching mirrors the attach cron's binding key: Automation.catnoTag,
+ * case-insensitive. The newest campaign wins when a SKU was re-campaigned.
+ *
+ * Auth: Bearer CRON_SECRET (same contract as the cron routes).
+ */
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET || process.env.NEXTAUTH_SECRET;
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const sku = request.nextUrl.searchParams.get("sku")?.trim();
+  if (!sku) {
+    return NextResponse.json(
+      { success: false, error: "sku query parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  const automation = await prisma.automation.findFirst({
+    where: { catnoTag: { equals: sku, mode: "insensitive" } },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, name: true, isActive: true, postId: true, createdAt: true },
+  });
+
+  if (!automation) {
+    return NextResponse.json({ success: true, data: { automation: null } });
+  }
+
+  const [dmSent, clicks] = await Promise.all([
+    prisma.dmLog.count({ where: { automationId: automation.id, status: "SENT" } }),
+    prisma.linkClick.count({ where: { automationId: automation.id } }),
+  ]);
+
+  return NextResponse.json({
+    success: true,
+    data: { automation: { ...automation, dmSent, clicks } },
+  });
+}

--- a/app/api/internal/lint-copy/route.ts
+++ b/app/api/internal/lint-copy/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from "next/server";
+import { lintText } from "@/lib/copy/copy-linter";
+
+/**
+ * Internal copy-lint endpoint — lets sibling services on this host (the
+ * label-platform marketing calendar) lint human-written captions against the
+ * YOYAKU voice rules without re-implementing the linter.
+ *
+ * POST { text: string, nouns?: string[] }
+ *
+ * When no fact-block nouns are supplied, the invented-noun rule is dropped:
+ * without a fact block every real artist/label name would be a false
+ * positive. All style rules (emoji, dashes, clichés, hooks, triads,
+ * exclamations) still apply.
+ *
+ * Auth: Bearer CRON_SECRET (same contract as the cron routes — this API is
+ * loopback-only in practice, nginx does not route /api/internal/*).
+ */
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET || process.env.NEXTAUTH_SECRET;
+
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  let body: { text?: unknown; nouns?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const text = typeof body.text === "string" ? body.text : "";
+  const hasNouns = Array.isArray(body.nouns);
+  const nouns = hasNouns
+    ? (body.nouns as unknown[]).filter((n): n is string => typeof n === "string")
+    : [];
+
+  let violations = lintText(text, nouns);
+  if (!hasNouns) {
+    violations = violations.filter((v) => v.rule !== "invented-noun");
+  }
+
+  return NextResponse.json({
+    success: true,
+    data: { ok: violations.length === 0, violations },
+  });
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,6 +6,20 @@ export const metadata = {
   description: "Sign in to manage Instagram comment-to-DM campaigns.",
 };
 
+const ERROR_MESSAGES: Record<string, string> = {
+  AccessDenied:
+    "This email is not allowed on this workspace. Use your work account, or ask the workspace owner for access.",
+  OAuthAccountNotLinked:
+    "This email is already registered with another sign-in method. Use the method you signed up with.",
+  Verification:
+    "That sign-in link is invalid or has expired. Request a new one below.",
+};
+
+function errorMessage(code?: string): string | null {
+  if (!code) return null;
+  return ERROR_MESSAGES[code] ?? "Sign-in failed. Please try again.";
+}
+
 export default async function LoginPage({
   searchParams,
 }: {
@@ -13,15 +27,23 @@ export default async function LoginPage({
     checkEmail?: string;
     callbackUrl?: string;
     template?: string;
+    error?: string;
   }>;
 }) {
   const params = await searchParams;
   const checkEmail = params.checkEmail === "1";
+  const authError = errorMessage(params.error);
   const selectedTemplate = getCampaignTemplate(params.template);
   const templateCallbackUrl = selectedTemplate
     ? `/campaigns/new?template=${selectedTemplate.slug}`
     : null;
   const callbackUrl = params.callbackUrl ?? templateCallbackUrl ?? "/dashboard";
+  const googleConfigured = Boolean(process.env.GOOGLE_CLIENT_ID);
+
+  async function signInWithGoogle() {
+    "use server";
+    await signIn("google", { redirectTo: callbackUrl });
+  }
 
   async function sendMagicLink(formData: FormData) {
     "use server";
@@ -35,23 +57,30 @@ export default async function LoginPage({
     <div className="min-h-screen flex items-center justify-center px-6">
       <div className="w-full max-w-md">
         <div className="text-center mb-8">
-          <h1 className="text-2xl font-semibold text-foreground">
-            OpenReply
-          </h1>
+          <h1 className="text-2xl font-semibold text-foreground">OpenReply</h1>
           <p className="text-muted text-sm leading-relaxed mt-2">
             {selectedTemplate
               ? `Sign in to use the ${selectedTemplate.title} template.`
-              : "Sign in by email, then connect your Instagram professional account."}
+              : "Sign in to manage Instagram comment-to-DM campaigns."}
           </p>
         </div>
 
-        <div className="panel rounded p-8 shadow-black/40">
+        <div className="panel rounded p-8">
+          {authError && (
+            <div
+              role="alert"
+              className="mb-5 rounded border border-error/40 bg-error/10 p-4 text-sm text-foreground"
+            >
+              {authError}
+            </div>
+          )}
+
           {selectedTemplate && !checkEmail && (
-            <div className="mb-5 border border-cyan-200/20 bg-cyan-300/10 p-4">
-              <p className="text-xs font-semibold uppercase tracking-wide text-cyan-100">
+            <div className="mb-5 rounded border border-border bg-surface p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted">
                 Template selected
               </p>
-              <p className="mt-2 text-sm font-semibold text-white">
+              <p className="mt-2 text-sm font-semibold text-foreground">
                 {selectedTemplate.title}
               </p>
             </div>
@@ -66,32 +95,68 @@ export default async function LoginPage({
               </p>
             </div>
           ) : (
-            <form action={sendMagicLink} className="space-y-5">
-              <div className="space-y-2">
-                <label
-                  htmlFor="email"
-                  className="block text-sm font-medium text-foreground"
-                >
-                  Work email
-                </label>
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  required
-                  autoComplete="email"
-                  placeholder="you@company.com"
-                  className="w-full px-4 py-3 rounded bg-surface border border-border text-sm text-foreground placeholder:text-zinc-500 focus:border-accent/40 focus:outline-none transition-colors"
-                />
-              </div>
+            <div className="space-y-5">
+              {googleConfigured && (
+                <>
+                  <form action={signInWithGoogle}>
+                    <button
+                      type="submit"
+                      className="w-full inline-flex items-center justify-center gap-3 rounded bg-accent px-6 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-accent-hover"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        width="18"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                      >
+                        <path d="M21.35 11.1H12v3.8h5.35c-.5 2.4-2.55 3.8-5.35 3.8a5.7 5.7 0 1 1 0-11.4c1.45 0 2.75.5 3.78 1.48l2.85-2.85A9.53 9.53 0 0 0 12 2.5a9.5 9.5 0 1 0 0 19c5.48 0 9.1-3.85 9.1-9.27 0-.38-.03-.76-.1-1.13Z" />
+                      </svg>
+                      Sign in with Google
+                    </button>
+                  </form>
 
-              <button
-                type="submit"
-                className="w-full inline-flex items-center justify-center gap-2 rounded bg-accent px-6 py-3.5 text-sm font-semibold text-white shadow-indigo-500/25 transition-all hover:shadow-indigo-500/30"
-              >
-                Email me a magic link
-              </button>
-            </form>
+                  <div className="flex items-center gap-3">
+                    <div className="h-px flex-1 bg-border" />
+                    <span className="text-xs uppercase tracking-wide text-muted">
+                      or
+                    </span>
+                    <div className="h-px flex-1 bg-border" />
+                  </div>
+                </>
+              )}
+
+              <form action={sendMagicLink} className="space-y-4">
+                <div className="space-y-2">
+                  <label
+                    htmlFor="email"
+                    className="block text-sm font-medium text-foreground"
+                  >
+                    Work email
+                  </label>
+                  <input
+                    id="email"
+                    name="email"
+                    type="email"
+                    required
+                    autoComplete="email"
+                    placeholder="you@company.com"
+                    className="w-full px-4 py-3 rounded bg-surface border border-border text-sm text-foreground placeholder:text-zinc-500 focus:border-accent/40 focus:outline-none transition-colors"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  className={
+                    googleConfigured
+                      ? "w-full inline-flex items-center justify-center rounded border border-border bg-surface px-6 py-3 text-sm font-medium text-foreground transition-colors hover:bg-surface-hover"
+                      : "w-full inline-flex items-center justify-center rounded bg-accent px-6 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-accent-hover"
+                  }
+                >
+                  Email me a magic link
+                </button>
+              </form>
+            </div>
           )}
         </div>
       </div>

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -150,3 +150,6 @@ networks:
   backend:
     name: openreply-backend
     internal: true
+    ipam:
+      config:
+        - subnet: 10.250.48.0/24

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -85,6 +85,8 @@ services:
     init: true
     env_file:
       - .env
+    environment:
+      AUTH_ALLOWED_EMAILS: ${AUTH_ALLOWED_EMAILS:?AUTH_ALLOWED_EMAILS is required}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -92,6 +92,7 @@ services:
         condition: service_healthy
     networks:
       - backend
+      - edge
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -1,0 +1,150 @@
+name: openreply
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: openreply-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: openreply
+      POSTGRES_USER: openreply
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - /mnt/data/openreply/postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U openreply -d openreply"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - backend
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 256
+    mem_limit: 768m
+
+  redis:
+    image: redis:7-alpine
+    container_name: openreply-redis
+    restart: unless-stopped
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    command:
+      - sh
+      - -ec
+      - exec redis-server --appendonly yes --requirepass "$$REDIS_PASSWORD"
+    volumes:
+      - /mnt/data/openreply/redis:/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'redis-cli --no-auth-warning -a "$$REDIS_PASSWORD" ping | grep -qx PONG',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - backend
+    security_opt:
+      - no-new-privileges:true
+    pids_limit: 128
+    mem_limit: 256m
+
+  migrate:
+    image: openreply-worker:${OPENREPLY_IMAGE_TAG:-local}
+    build:
+      context: .
+      target: worker
+    env_file:
+      - .env
+    command: ["npm", "run", "db:migrate"]
+    restart: "no"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - backend
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    pids_limit: 128
+    mem_limit: 512m
+
+  worker:
+    image: openreply-worker:${OPENREPLY_IMAGE_TAG:-local}
+    build:
+      context: .
+      target: worker
+    container_name: openreply-worker
+    restart: unless-stopped
+    init: true
+    env_file:
+      - .env
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    networks:
+      - backend
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+    pids_limit: 256
+    mem_limit: 768m
+
+  web:
+    image: openreply-web:${OPENREPLY_IMAGE_TAG:-local}
+    build:
+      context: .
+      target: web
+    container_name: openreply-web
+    restart: unless-stopped
+    init: true
+    env_file:
+      - .env
+    depends_on:
+      migrate:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${OPENREPLY_PORT:-3048}:3000"
+    networks:
+      - backend
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 10s
+      start_period: 60s
+      retries: 5
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,mode=1777
+      - /app/.next/cache:size=128m,mode=0755,uid=1001,gid=1001
+    pids_limit: 256
+    mem_limit: 768m
+
+networks:
+  backend:
+    name: openreply-backend
+    internal: true

--- a/compose.production.yml
+++ b/compose.production.yml
@@ -85,8 +85,6 @@ services:
     init: true
     env_file:
       - .env
-    environment:
-      AUTH_ALLOWED_EMAILS: ${AUTH_ALLOWED_EMAILS:?AUTH_ALLOWED_EMAILS is required}
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -114,6 +112,8 @@ services:
     init: true
     env_file:
       - .env
+    environment:
+      AUTH_ALLOWED_EMAILS: ${AUTH_ALLOWED_EMAILS:?AUTH_ALLOWED_EMAILS is required}
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -123,6 +123,7 @@ services:
       - "127.0.0.1:${OPENREPLY_PORT:-3048}:3000"
     networks:
       - backend
+      - edge
     healthcheck:
       test:
         [
@@ -153,3 +154,8 @@ networks:
     ipam:
       config:
         - subnet: 10.250.48.0/24
+  edge:
+    name: openreply-edge
+    ipam:
+      config:
+        - subnet: 10.250.49.0/24

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,33 @@
+# YOYAKU production deployment
+
+OpenReply runs as four isolated services on `yoyaku-automation`:
+
+- Next.js web/API on host loopback port `3048`
+- long-running BullMQ worker
+- dedicated PostgreSQL 16
+- dedicated Redis 7
+
+The public edge is `https://openreply.yoyaku.fr` through nginx. PostgreSQL and
+Redis have no host ports. Persistent data and backups live under
+`/mnt/data/openreply`.
+
+## Deploy
+
+1. Clone this fork into `/opt/openreply`.
+2. Copy `deploy/openreply.env.example` to `.env`, replace every placeholder,
+   and set mode `0600`.
+3. Create `/mnt/data/openreply/{postgres,redis,backups}` with ownership suitable
+   for the official container images.
+4. Run:
+
+   ```bash
+   docker compose -f compose.production.yml config --quiet
+   docker compose -f compose.production.yml build
+   docker compose -f compose.production.yml up -d
+   ```
+
+5. Install the nginx vhost and systemd units from `deploy/`.
+6. Confirm `/api/health` returns `status: ok` and `worker.healthy: true`.
+
+The populated `.env` must never enter Git. `ENCRYPTION_KEY` is irreplaceable:
+losing it forces every Instagram account to reconnect.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -8,8 +8,10 @@ OpenReply runs as four isolated services on `yoyaku-automation`:
 - dedicated Redis 7
 
 The public edge is `https://openreply.yoyaku.fr` through nginx. PostgreSQL and
-Redis have no host ports. Persistent data and backups live under
-`/mnt/data/openreply`.
+Redis have no host ports. Persistent data and local backups live under
+`/mnt/data/openreply`. Daily PostgreSQL dumps are retained locally for 14 days
+and replicated to `yoyaku-hetzner:/opt/backups/openreply-automation` with
+30-day retention so the recovery copy does not share the application host.
 
 ## Deploy
 

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 readonly APP_DIR="/opt/openreply"
 readonly BACKUP_DIR="/mnt/data/openreply/backups"
+readonly REMOTE_BACKUP_HOST="yoyaku-hetzner"
+readonly REMOTE_BACKUP_DIR="/opt/backups/openreply-automation"
+readonly LOCAL_RETENTION_DAYS=14
+readonly REMOTE_RETENTION_DAYS=30
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 readonly TIMESTAMP
 readonly FINAL_PATH="${BACKUP_DIR}/openreply-${TIMESTAMP}.dump"
@@ -20,4 +24,20 @@ test -s "$TEMP_PATH"
 mv "$TEMP_PATH" "$FINAL_PATH"
 sha256sum "$FINAL_PATH" > "${FINAL_PATH}.sha256"
 
-printf 'OpenReply backup created: %s\n' "$FINAL_PATH"
+ssh "$REMOTE_BACKUP_HOST" install -d -m 0700 "$REMOTE_BACKUP_DIR"
+rsync --archive --chmod=F600 \
+  "$FINAL_PATH" "${FINAL_PATH}.sha256" \
+  "${REMOTE_BACKUP_HOST}:${REMOTE_BACKUP_DIR}/"
+
+find "$BACKUP_DIR" -maxdepth 1 -type f \
+  -name "openreply-*.dump" -mtime "+${LOCAL_RETENTION_DAYS}" -delete
+find "$BACKUP_DIR" -maxdepth 1 -type f \
+  -name "openreply-*.dump.sha256" -mtime "+${LOCAL_RETENTION_DAYS}" -delete
+
+ssh "$REMOTE_BACKUP_HOST" \
+  "find '$REMOTE_BACKUP_DIR' -maxdepth 1 -type f -name 'openreply-*.dump' -mtime '+$REMOTE_RETENTION_DAYS' -delete"
+ssh "$REMOTE_BACKUP_HOST" \
+  "find '$REMOTE_BACKUP_DIR' -maxdepth 1 -type f -name 'openreply-*.dump.sha256' -mtime '+$REMOTE_RETENTION_DAYS' -delete"
+
+printf 'OpenReply backup created and replicated: %s -> %s:%s/\n' \
+  "$FINAL_PATH" "$REMOTE_BACKUP_HOST" "$REMOTE_BACKUP_DIR"

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly APP_DIR="/opt/openreply"
+readonly BACKUP_DIR="/mnt/data/openreply/backups"
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+readonly TIMESTAMP
+readonly FINAL_PATH="${BACKUP_DIR}/openreply-${TIMESTAMP}.dump"
+readonly TEMP_PATH="${FINAL_PATH}.tmp"
+
+umask 077
+install -d -m 0700 "$BACKUP_DIR"
+
+cd "$APP_DIR"
+docker compose -f compose.production.yml exec -T postgres \
+  pg_dump --username=openreply --dbname=openreply --format=custom \
+  > "$TEMP_PATH"
+
+test -s "$TEMP_PATH"
+mv "$TEMP_PATH" "$FINAL_PATH"
+sha256sum "$FINAL_PATH" > "${FINAL_PATH}.sha256"
+
+printf 'OpenReply backup created: %s\n' "$FINAL_PATH"

--- a/deploy/backup.sh
+++ b/deploy/backup.sh
@@ -9,7 +9,9 @@ readonly LOCAL_RETENTION_DAYS=14
 readonly REMOTE_RETENTION_DAYS=30
 TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 readonly TIMESTAMP
-readonly FINAL_PATH="${BACKUP_DIR}/openreply-${TIMESTAMP}.dump"
+readonly FINAL_NAME="openreply-${TIMESTAMP}.dump"
+readonly FINAL_PATH="${BACKUP_DIR}/${FINAL_NAME}"
+readonly CHECKSUM_PATH="${FINAL_PATH}.sha256"
 readonly TEMP_PATH="${FINAL_PATH}.tmp"
 
 umask 077
@@ -22,11 +24,14 @@ docker compose -f compose.production.yml exec -T postgres \
 
 test -s "$TEMP_PATH"
 mv "$TEMP_PATH" "$FINAL_PATH"
-sha256sum "$FINAL_PATH" > "${FINAL_PATH}.sha256"
+(
+  cd "$BACKUP_DIR"
+  sha256sum "$FINAL_NAME" > "${FINAL_NAME}.sha256"
+)
 
 ssh "$REMOTE_BACKUP_HOST" install -d -m 0700 "$REMOTE_BACKUP_DIR"
 rsync --archive --chmod=F600 \
-  "$FINAL_PATH" "${FINAL_PATH}.sha256" \
+  "$FINAL_PATH" "$CHECKSUM_PATH" \
   "${REMOTE_BACKUP_HOST}:${REMOTE_BACKUP_DIR}/"
 
 find "$BACKUP_DIR" -maxdepth 1 -type f \

--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Calls OpenReply's application cron endpoints. Upstream relies on Vercel's
+# scheduler (vercel.json); self-hosted deployments must drive these routes
+# themselves or Instagram tokens silently expire after 60 days, follower
+# history never accumulates, and pending campaigns never bind to posts.
+set -euo pipefail
+
+readonly APP_DIR="/opt/openreply"
+readonly BASE_URL="http://127.0.0.1:3048"
+
+secret="$(grep -m1 '^CRON_SECRET=' "$APP_DIR/.env" | cut -d= -f2-)"
+if [ -z "$secret" ]; then
+  secret="$(grep -m1 '^NEXTAUTH_SECRET=' "$APP_DIR/.env" | cut -d= -f2-)"
+fi
+test -n "$secret"
+
+status=0
+for route in refresh-tokens snapshot-followers attach-next-reel sync-releases; do
+  code=$(curl -sS -o /tmp/openreply-cron-last.json -w '%{http_code}' \
+    --max-time 120 \
+    -H "Authorization: Bearer ${secret}" \
+    "${BASE_URL}/api/cron/${route}") || code=000
+  if [ "$code" != "200" ]; then
+    echo "openreply-cron: ${route} returned ${code}: $(head -c 300 /tmp/openreply-cron-last.json)" >&2
+    status=1
+  else
+    echo "openreply-cron: ${route} ok $(head -c 200 /tmp/openreply-cron-last.json)"
+  fi
+done
+
+exit "$status"

--- a/deploy/cron.sh
+++ b/deploy/cron.sh
@@ -14,17 +14,23 @@ if [ -z "$secret" ]; then
 fi
 test -n "$secret"
 
+# Unpredictable temp path (no symlink attacks in shared /tmp), cleaned on exit.
+body_file="$(mktemp)"
+trap 'rm -f "$body_file"' EXIT
+
 status=0
 for route in refresh-tokens snapshot-followers attach-next-reel sync-releases; do
-  code=$(curl -sS -o /tmp/openreply-cron-last.json -w '%{http_code}' \
+  # The auth header goes through curl's config-from-stdin so the secret never
+  # appears in the process argv (visible to every local user via ps).
+  code=$(curl -sS -o "$body_file" -w '%{http_code}' \
     --max-time 120 \
-    -H "Authorization: Bearer ${secret}" \
+    --config <(printf 'header = "Authorization: Bearer %s"\n' "$secret") \
     "${BASE_URL}/api/cron/${route}") || code=000
   if [ "$code" != "200" ]; then
-    echo "openreply-cron: ${route} returned ${code}: $(head -c 300 /tmp/openreply-cron-last.json)" >&2
+    echo "openreply-cron: ${route} returned ${code}" >&2
     status=1
   else
-    echo "openreply-cron: ${route} ok $(head -c 200 /tmp/openreply-cron-last.json)"
+    echo "openreply-cron: ${route} ok $(head -c 200 "$body_file")"
   fi
 done
 

--- a/deploy/healthcheck.sh
+++ b/deploy/healthcheck.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --max-time 15 \
+  https://openreply.yoyaku.fr/api/health \
+  >/dev/null

--- a/deploy/nginx/openreply.yoyaku.fr.conf
+++ b/deploy/nginx/openreply.yoyaku.fr.conf
@@ -1,0 +1,42 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name openreply.yoyaku.fr;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name openreply.yoyaku.fr;
+
+    access_log /var/log/nginx/openreply.yoyaku.fr.access.log;
+    error_log /var/log/nginx/openreply.yoyaku.fr.error.log;
+
+    ssl_certificate /etc/letsencrypt/live/openreply.yoyaku.fr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/openreply.yoyaku.fr/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    client_max_body_size 2m;
+
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+    location / {
+        proxy_pass http://127.0.0.1:3048;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 60s;
+        proxy_connect_timeout 5s;
+    }
+}

--- a/deploy/nginx/openreply.yoyaku.fr.conf
+++ b/deploy/nginx/openreply.yoyaku.fr.conf
@@ -32,8 +32,6 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
         proxy_buffering off;
         proxy_request_buffering off;
         proxy_read_timeout 60s;

--- a/deploy/openreply.env.example
+++ b/deploy/openreply.env.example
@@ -1,0 +1,23 @@
+# Copy to /opt/openreply/.env and chmod 600. Never commit the populated file.
+NEXTAUTH_URL=https://openreply.example.com
+NEXTAUTH_SECRET=generate-with-openssl-rand-base64-32
+CRON_SECRET=generate-with-openssl-rand-hex-32
+ENCRYPTION_KEY=generate-with-openssl-rand-hex-32
+
+POSTGRES_PASSWORD=generate-with-openssl-rand-hex-32
+REDIS_PASSWORD=generate-with-openssl-rand-hex-32
+DATABASE_URL=postgresql://openreply:POSTGRES_PASSWORD@postgres:5432/openreply
+REDIS_URL=redis://:REDIS_PASSWORD@redis:6379
+
+RESEND_API_KEY=re_replace
+EMAIL_FROM=OpenReply <login@example.com>
+AUTH_ALLOWED_EMAILS=owner@example.com
+
+META_GRAPH_API_VERSION=v25.0
+INSTAGRAM_APP_ID=replace
+INSTAGRAM_APP_SECRET=replace
+FACEBOOK_APP_SECRET=replace
+WEBHOOK_VERIFY_TOKEN=generate-with-openssl-rand-hex-32
+
+OPENREPLY_PORT=3048
+OPENREPLY_IMAGE_TAG=local

--- a/deploy/systemd/openreply-backup.service
+++ b/deploy/systemd/openreply-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Create an OpenReply PostgreSQL backup
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/openreply/deploy/backup.sh
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/deploy/systemd/openreply-backup.timer
+++ b/deploy/systemd/openreply-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Daily OpenReply PostgreSQL backup
+
+[Timer]
+OnCalendar=*-*-* 03:15:00 Europe/Paris
+Persistent=true
+RandomizedDelaySec=10m
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/openreply-cron.service
+++ b/deploy/systemd/openreply-cron.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Drive OpenReply application cron endpoints
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/openreply/deploy/cron.sh

--- a/deploy/systemd/openreply-cron.timer
+++ b/deploy/systemd/openreply-cron.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=OpenReply application crons every 15 minutes
+
+[Timer]
+OnBootSec=3m
+OnUnitActiveSec=15m
+AccuracySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/openreply-healthcheck.service
+++ b/deploy/systemd/openreply-healthcheck.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check the public OpenReply health endpoint
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/opt/openreply/deploy/healthcheck.sh

--- a/deploy/systemd/openreply-healthcheck.timer
+++ b/deploy/systemd/openreply-healthcheck.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Monitor OpenReply every five minutes
+
+[Timer]
+OnBootSec=2m
+OnUnitActiveSec=5m
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/lib/auth-allowlist.ts
+++ b/lib/auth-allowlist.ts
@@ -11,12 +11,11 @@ export function isAuthEmailAllowed(
   email: string | null | undefined,
   rawAllowlist?: string
 ): boolean {
-  const allowlist = parseAuthEmailAllowlist(rawAllowlist);
-
   // Preserve upstream's public-signup behavior unless the self-hoster opts in
-  // to a restriction.
-  if (allowlist.size === 0) return true;
+  // to a restriction. A present but malformed value fails closed.
+  if (rawAllowlist === undefined || rawAllowlist === "") return true;
   if (!email) return false;
 
+  const allowlist = parseAuthEmailAllowlist(rawAllowlist);
   return allowlist.has(email.trim().toLowerCase());
 }

--- a/lib/auth-allowlist.ts
+++ b/lib/auth-allowlist.ts
@@ -1,0 +1,22 @@
+export function parseAuthEmailAllowlist(raw?: string): Set<string> {
+  return new Set(
+    (raw ?? "")
+      .split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean)
+  );
+}
+
+export function isAuthEmailAllowed(
+  email: string | null | undefined,
+  rawAllowlist?: string
+): boolean {
+  const allowlist = parseAuthEmailAllowlist(rawAllowlist);
+
+  // Preserve upstream's public-signup behavior unless the self-hoster opts in
+  // to a restriction.
+  if (allowlist.size === 0) return true;
+  if (!email) return false;
+
+  return allowlist.has(email.trim().toLowerCase());
+}

--- a/lib/auth-allowlist.ts
+++ b/lib/auth-allowlist.ts
@@ -7,6 +7,15 @@ export function parseAuthEmailAllowlist(raw?: string): Set<string> {
   );
 }
 
+export function parseAuthDomainAllowlist(raw?: string): Set<string> {
+  return new Set(
+    (raw ?? "")
+      .split(",")
+      .map((domain) => domain.trim().toLowerCase().replace(/^@/, ""))
+      .filter(Boolean)
+  );
+}
+
 export function isAuthEmailAllowed(
   email: string | null | undefined,
   rawAllowlist?: string
@@ -18,4 +27,40 @@ export function isAuthEmailAllowed(
 
   const allowlist = parseAuthEmailAllowlist(rawAllowlist);
   return allowlist.has(email.trim().toLowerCase());
+}
+
+export function isAuthDomainAllowed(
+  email: string | null | undefined,
+  rawDomains?: string
+): boolean {
+  if (rawDomains === undefined || rawDomains === "") return true;
+  if (!email) return false;
+
+  const domain = email.trim().toLowerCase().split("@")[1] ?? "";
+  if (!domain) return false;
+
+  return parseAuthDomainAllowlist(rawDomains).has(domain);
+}
+
+/**
+ * Combined sign-in gate. With neither list configured, public signup is
+ * preserved (upstream behavior). With at least one configured, an email must
+ * match the explicit address list OR the domain list; a present-but-blank
+ * value keeps failing closed, matching the historical email-list semantics.
+ */
+export function isAuthSignInAllowed(
+  email: string | null | undefined,
+  rawEmailAllowlist?: string,
+  rawDomainAllowlist?: string
+): boolean {
+  const emailsUnset = rawEmailAllowlist === undefined || rawEmailAllowlist === "";
+  const domainsUnset = rawDomainAllowlist === undefined || rawDomainAllowlist === "";
+
+  if (emailsUnset && domainsUnset) return true;
+  if (!email) return false;
+
+  const byEmail = !emailsUnset && isAuthEmailAllowed(email, rawEmailAllowlist);
+  const byDomain = !domainsUnset && isAuthDomainAllowed(email, rawDomainAllowlist);
+
+  return byEmail || byDomain;
 }

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,10 @@
 import NextAuth, { type NextAuthConfig } from "next-auth";
 import Resend from "next-auth/providers/resend";
+import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/db/client";
 import { ensureWorkspaceForUser, getPrimaryWorkspace } from "@/lib/workspace";
-import { isAuthEmailAllowed } from "@/lib/auth-allowlist";
+import { isAuthSignInAllowed } from "@/lib/auth-allowlist";
 
 type AdapterPrismaClient = Parameters<typeof PrismaAdapter>[0];
 
@@ -14,10 +15,28 @@ export const authConfig = {
       apiKey: process.env.RESEND_API_KEY ?? "missing-resend-api-key",
       from: process.env.EMAIL_FROM ?? "OpenReply <login@example.com>",
     }),
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "missing-google-client-id",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "missing-google-client-secret",
+      // Safe here: the domain/email allowlist below gates who can arrive, and
+      // magic-link users have no Account row, so without this flag their first
+      // Google sign-in would dead-end on OAuthAccountNotLinked.
+      allowDangerousEmailAccountLinking: true,
+    }),
   ],
   callbacks: {
-    async signIn({ user }) {
-      return isAuthEmailAllowed(user.email, process.env.AUTH_ALLOWED_EMAILS);
+    async signIn({ user, account, profile }) {
+      // A Google account whose email Google itself has not verified never
+      // passes, whatever the allowlists say.
+      if (account?.provider === "google" && profile?.email_verified !== true) {
+        return false;
+      }
+
+      return isAuthSignInAllowed(
+        user.email,
+        process.env.AUTH_ALLOWED_EMAILS,
+        process.env.AUTH_ALLOWED_DOMAINS
+      );
     },
     async session({ session, user }) {
       if (session.user) {
@@ -36,6 +55,10 @@ export const authConfig = {
   pages: {
     signIn: "/login",
     verifyRequest: "/verify-request",
+    // A denied sign-in (domain not allowed, unverified Google email) comes
+    // back to the styled login page with ?error=AccessDenied instead of the
+    // bare NextAuth error page.
+    error: "/login",
   },
   session: {
     strategy: "database",

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -3,6 +3,7 @@ import Resend from "next-auth/providers/resend";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/db/client";
 import { ensureWorkspaceForUser, getPrimaryWorkspace } from "@/lib/workspace";
+import { isAuthEmailAllowed } from "@/lib/auth-allowlist";
 
 type AdapterPrismaClient = Parameters<typeof PrismaAdapter>[0];
 
@@ -15,6 +16,9 @@ export const authConfig = {
     }),
   ],
   callbacks: {
+    async signIn({ user }) {
+      return isAuthEmailAllowed(user.email, process.env.AUTH_ALLOWED_EMAILS);
+    },
     async session({ session, user }) {
       if (session.user) {
         session.user.id = user.id;

--- a/lib/automations/create-generated.ts
+++ b/lib/automations/create-generated.ts
@@ -1,0 +1,69 @@
+/**
+ * Creates a campaign from generated YOYAKU copy.
+ *
+ * Deliberately narrower than the interactive POST /api/automations route:
+ * generated campaigns are born INACTIVE (a human reviews and activates during
+ * the trial period), pending a post, and carry the catno so the attach cron
+ * can bind them to the exact media whose caption contains #<catno>.
+ */
+
+import { prisma } from "@/lib/db/client";
+import { generateTrackedLinkSlug } from "@/lib/tracking/server";
+import { generateReportShareSlug } from "@/lib/reports/share";
+import type { CampaignCopy } from "@/lib/copy/yoyaku-patterns";
+
+export interface GeneratedCampaignInput {
+  copy: CampaignCopy;
+  /** Catalogue number used for #catno post binding; null for instore. */
+  catnoTag: string | null;
+  workspaceId: string;
+  instagramAccountId: string;
+  isActive: boolean;
+}
+
+export async function createGeneratedCampaign(input: GeneratedCampaignInput) {
+  const { copy, workspaceId } = input;
+
+  const linkCreates = [
+    {
+      workspaceId,
+      slug: generateTrackedLinkSlug(),
+      label: "Primary campaign link",
+      destinationUrl: copy.trackedDestinationUrl,
+    },
+  ];
+  if (copy.secondaryDestinationUrl) {
+    linkCreates.push({
+      workspaceId,
+      slug: generateTrackedLinkSlug(),
+      label: copy.secondaryButtonLabel ?? "Open link",
+      destinationUrl: copy.secondaryDestinationUrl,
+    });
+  }
+
+  return prisma.automation.create({
+    data: {
+      name: copy.name,
+      goal: copy.goal,
+      postId: null,
+      postUrl: null,
+      pendingNextReel: true,
+      catnoTag: input.catnoTag,
+      matchAnyPost: false,
+      keywords: [],
+      matchAnyWord: true,
+      dmMessage: copy.dmMessage,
+      openingDmEnabled: true,
+      openingDmMessage: copy.openingDmMessage,
+      openingDmButtonLabel: copy.openingDmButtonLabel,
+      linkButtonLabel: copy.linkButtonLabel,
+      isActive: input.isActive,
+      wholeWordMatch: true,
+      workspaceId,
+      instagramAccountId: input.instagramAccountId,
+      reportShareSlug: generateReportShareSlug(),
+      trackedLinks: { create: linkCreates },
+    },
+    include: { trackedLinks: true },
+  });
+}

--- a/lib/copy/copy-linter.ts
+++ b/lib/copy/copy-linter.ts
@@ -1,0 +1,189 @@
+/**
+ * Anti-cliché linter for YOYAKU DM copy.
+ *
+ * Ported from the proven email style guard (pretooluse-email-cascade-guard.py
+ * check_style) and extended with the tics observed in the legacy ManyChat
+ * campaigns. A rejected text never becomes a campaign: the linter is a hard
+ * gate at generation time and a warning surface for manual edits.
+ *
+ * The one rule that is not cosmetic: every proper noun in the text must come
+ * from the fact block. This is the executable form of rules/01 "NEVER invent
+ * or sharpen a name".
+ */
+
+import { META_BODY_LIMIT, META_BUTTON_LIMIT } from "./yoyaku-patterns";
+import type { CampaignCopy } from "./yoyaku-patterns";
+import { factNouns } from "./release-facts";
+import type { CampaignFacts } from "./release-facts";
+
+export interface LintViolation {
+  rule: string;
+  detail: string;
+}
+
+export interface LintResult {
+  ok: boolean;
+  violations: LintViolation[];
+}
+
+const EMOJI = /\p{Extended_Pictographic}|️/u;
+const DASHES = /[—–]/;
+
+const BAD_OPENINGS = /^(hey|hey there|hi there|hello there)\b/i;
+
+const CLICHES: readonly RegExp[] = [
+  /\bdive (in|into)\b/i,
+  /\bworld of\b/i,
+  /\b\w+'s world\b/i,
+  /\bjourney\b/i,
+  /\bfresh (perspective|take)\b/i,
+  /\b(elevate|unlock|leverage|showcase|streamline|empower|foster|amplify|curate)\b/i,
+  /\bgame.?changer\b/i,
+];
+
+const RHETORICAL_HOOKS: readonly RegExp[] = [
+  /you'?re in the right place/i,
+  /\bwanna (hear|see|listen)\b/i,
+  /\blet'?s listen\b/i,
+  /^looking for\b/i,
+  /\bready to\b/i,
+];
+
+const FAKE_PERSONALIZATION: readonly RegExp[] = [
+  /i hope this (email|message|note) finds you well/i,
+  /i wanted to personally reach out/i,
+  /please (do not|don'?t) hesitate/i,
+  /feel free to (contact|reach out|get in touch)/i,
+  /looking forward to hearing/i,
+];
+
+/** Three-item "X, Y, and Z" lists — the adjective-triad tell. */
+const TRIAD = /,[^,.!?]+,\s*and\s+/i;
+
+/**
+ * Words our hand-written shells legitimately capitalize outside fact nouns.
+ * Anything else capitalized must appear in the fact block.
+ */
+const ALLOWED_CAPITALIZED = new Set([
+  "preorder",
+  "preorders",
+  "restock",
+  "new",
+  "out",
+  "copies",
+  "here",
+  "there",
+  "the",
+  "full",
+  "send",
+  "get",
+  "watch",
+  "youtube",
+  "soundcloud",
+  "instore",
+  "yoyaku",
+]);
+
+function collectFactWords(nouns: string[]): Set<string> {
+  const words = new Set<string>();
+  for (const noun of nouns) {
+    words.add(noun.toLowerCase());
+    for (const word of noun.split(/[\s/&.,'-]+/)) {
+      if (word) words.add(word.toLowerCase());
+    }
+  }
+  return words;
+}
+
+function findInventedNouns(text: string, nouns: string[]): string[] {
+  const factWords = collectFactWords(nouns);
+  const invented: string[] = [];
+
+  for (const match of text.matchAll(/\b[A-Z][A-Za-z0-9'&-]*\b/g)) {
+    const word = match[0];
+    const lower = word.toLowerCase();
+    if (ALLOWED_CAPITALIZED.has(lower)) continue;
+    if (factWords.has(lower)) continue;
+    // All-caps tokens that are substrings of a fact (catno fragments) pass.
+    if (nouns.some((noun) => noun.toLowerCase().includes(lower))) continue;
+    invented.push(word);
+  }
+
+  return invented;
+}
+
+export function lintText(text: string, nouns: string[]): LintViolation[] {
+  const violations: LintViolation[] = [];
+  const add = (rule: string, detail: string) => violations.push({ rule, detail });
+
+  if (EMOJI.test(text)) add("no-emoji", "emoji are off-brand on YOYAKU accounts");
+  if (DASHES.test(text)) add("no-dashes", "em/en dashes are banned (rules/01)");
+  if (BAD_OPENINGS.test(text.trim())) add("no-hey-opening", `starts with a filler greeting`);
+
+  for (const pattern of CLICHES) {
+    const hit = text.match(pattern);
+    if (hit) add("cliche", `"${hit[0]}"`);
+  }
+  for (const pattern of RHETORICAL_HOOKS) {
+    const hit = text.match(pattern);
+    if (hit) add("rhetorical-hook", `"${hit[0]}"`);
+  }
+  for (const pattern of FAKE_PERSONALIZATION) {
+    const hit = text.match(pattern);
+    if (hit) add("fake-personalization", `"${hit[0]}"`);
+  }
+
+  if (TRIAD.test(text)) add("adjective-triad", "three-item list reads as marketing");
+
+  const exclamations = (text.match(/!/g) ?? []).length;
+  if (exclamations > 1) add("exclamation-overload", `${exclamations} exclamation marks`);
+
+  const inventedNouns = findInventedNouns(text, nouns);
+  if (inventedNouns.length > 0) {
+    add(
+      "invented-noun",
+      `proper noun(s) not in the fact block: ${inventedNouns.join(", ")}`
+    );
+  }
+
+  return violations;
+}
+
+/** Lint every user-visible field of a campaign against its fact block. */
+export function lintCampaignCopy(
+  copy: CampaignCopy,
+  facts: CampaignFacts
+): LintResult {
+  const nouns = factNouns(facts);
+  const violations: LintViolation[] = [];
+
+  for (const [field, value] of [
+    ["openingDmMessage", copy.openingDmMessage],
+    ["dmMessage", copy.dmMessage],
+  ] as const) {
+    for (const violation of lintText(value, nouns)) {
+      violations.push({ ...violation, detail: `${field}: ${violation.detail}` });
+    }
+    if (value.length > META_BODY_LIMIT) {
+      violations.push({
+        rule: "meta-body-limit",
+        detail: `${field} is ${value.length} chars (limit ${META_BODY_LIMIT})`,
+      });
+    }
+  }
+
+  for (const [field, value] of [
+    ["openingDmButtonLabel", copy.openingDmButtonLabel],
+    ["linkButtonLabel", copy.linkButtonLabel],
+    ["secondaryButtonLabel", copy.secondaryButtonLabel ?? ""],
+  ] as const) {
+    if (value.length > META_BUTTON_LIMIT) {
+      violations.push({
+        rule: "meta-button-limit",
+        detail: `${field} is ${value.length} chars (limit ${META_BUTTON_LIMIT})`,
+      });
+    }
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/lib/copy/release-facts.ts
+++ b/lib/copy/release-facts.ts
@@ -1,0 +1,66 @@
+/**
+ * The fact block every YOYAKU DM is built from.
+ *
+ * Facts are resolved mechanically from the shop (never invented, never
+ * sharpened) and flow into hand-written patterns. If a required fact is
+ * missing the campaign is NOT created; nothing is ever filled in.
+ */
+
+export type ReleaseEventType =
+  | "preorder_open"
+  | "release_live"
+  | "restock"
+  | "instore_published";
+
+export interface ReleaseFacts {
+  eventType: Exclude<ReleaseEventType, "instore_published">;
+  artist: string;
+  title: string;
+  /** Catalogue number — equals the WooCommerce SKU across the ecosystem. */
+  catno: string;
+  label: string;
+  /** Public product URL, always https://yoyaku.io/release/<slug>/ */
+  url: string;
+}
+
+export interface InstoreFacts {
+  eventType: "instore_published";
+  artist: string;
+  youtubeUrl: string;
+  /** Artist SoundCloud when set, otherwise the shop's channel. */
+  soundcloudUrl: string;
+}
+
+export type CampaignFacts = ReleaseFacts | InstoreFacts;
+
+/** Every proper-noun-bearing value of the fact block, for linter cross-checks. */
+export function factNouns(facts: CampaignFacts): string[] {
+  if (facts.eventType === "instore_published") {
+    return [facts.artist, "Yoyaku"];
+  }
+
+  return [facts.artist, facts.title, facts.catno, facts.label, "Yoyaku"];
+}
+
+const REQUIRED_RELEASE_FIELDS = [
+  "artist",
+  "title",
+  "catno",
+  "label",
+  "url",
+] as const;
+
+const REQUIRED_INSTORE_FIELDS = ["artist", "youtubeUrl", "soundcloudUrl"] as const;
+
+/** Returns the missing field names; an empty array means the block is usable. */
+export function missingFacts(facts: CampaignFacts): string[] {
+  const required =
+    facts.eventType === "instore_published"
+      ? REQUIRED_INSTORE_FIELDS
+      : REQUIRED_RELEASE_FIELDS;
+
+  return required.filter((field) => {
+    const value = (facts as unknown as Record<string, unknown>)[field];
+    return typeof value !== "string" || value.trim() === "";
+  });
+}

--- a/lib/copy/yoyaku-patterns.ts
+++ b/lib/copy/yoyaku-patterns.ts
@@ -1,0 +1,115 @@
+/**
+ * YOYAKU voice — hand-written DM patterns.
+ *
+ * Doctrine (rules/01 §Human-facing Writing + manychat-bible): say what
+ * happens, who does what, what is expected, then stop. Real facts poured
+ * into short shells. No emoji, ever. No em/en dashes. No rhetorical hooks,
+ * no adjective triads, no invented names. The linter in ./copy-linter.ts
+ * enforces all of this at generation time.
+ *
+ * Meta hard limits encoded here (lib/meta/client.ts): button-template body
+ * 640 chars, button title 20 chars (silently truncated beyond), 3 buttons.
+ */
+
+import type { CampaignFacts, InstoreFacts, ReleaseFacts } from "./release-facts";
+
+export const META_BODY_LIMIT = 640;
+export const META_BUTTON_LIMIT = 20;
+
+export interface CampaignCopy {
+  /** Campaign name shown in the OpenReply UI. */
+  name: string;
+  goal: string;
+  openingDmMessage: string;
+  openingDmButtonLabel: string;
+  /** The reveal DM that carries the link button(s). */
+  dmMessage: string;
+  /** Label of the primary link button (≤20 chars). */
+  linkButtonLabel: string;
+  trackedDestinationUrl: string;
+  secondaryDestinationUrl?: string;
+  secondaryButtonLabel?: string;
+}
+
+/**
+ * Deterministic variant pick: the same release always renders the same copy,
+ * so re-running the sync is idempotent and reviewable. Date.now()/random are
+ * deliberately absent.
+ */
+function pickVariant<T>(variants: readonly T[], seed: string): T {
+  let hash = 0;
+  for (const char of seed) hash = (hash * 31 + char.charCodeAt(0)) >>> 0;
+  return variants[hash % variants.length];
+}
+
+/** "Preorder ABC123" when it fits Meta's 20-char button, plain catno otherwise. */
+function preorderButtonLabel(catno: string): string {
+  const labeled = `Preorder ${catno}`;
+  if (labeled.length <= META_BUTTON_LIMIT) return labeled;
+  return catno.slice(0, META_BUTTON_LIMIT);
+}
+
+const OPENING_BUTTON_VARIANTS = ["Send the link", "Get the link"] as const;
+
+const REVEAL_VARIANTS = ["Here you go:", "There you go:"] as const;
+
+type ReleaseShell = (facts: ReleaseFacts) => string;
+
+const RELEASE_OPENINGS: Record<ReleaseFacts["eventType"], readonly ReleaseShell[]> = {
+  preorder_open: [
+    (f) => `${f.artist}, ${f.title}. Preorder is open on ${f.label}.`,
+    (f) => `${f.title} by ${f.artist} is up for preorder on ${f.label}.`,
+    (f) => `New on ${f.label}: ${f.artist}, ${f.title}. Preorders are open.`,
+  ],
+  release_live: [
+    (f) => `${f.artist}, ${f.title} is out now on ${f.label}.`,
+    (f) => `${f.title} by ${f.artist} just landed. Copies are in the shop.`,
+    (f) => `Out today: ${f.artist}, ${f.title} on ${f.label}.`,
+  ],
+  restock: [
+    (f) => `${f.artist}, ${f.title} is back in stock.`,
+    (f) => `Restock: ${f.artist}, ${f.title} on ${f.label}.`,
+  ],
+};
+
+const RELEASE_GOALS: Record<ReleaseFacts["eventType"], string> = {
+  preorder_open: "Preorder link",
+  release_live: "Release link",
+  restock: "Restock link",
+};
+
+const INSTORE_OPENINGS: readonly ((facts: InstoreFacts) => string)[] = [
+  (f) => `${f.artist} played an instore session at Yoyaku. The full set is up.`,
+  (f) => `New instore session: ${f.artist} at Yoyaku.`,
+];
+
+export function buildCampaignCopy(facts: CampaignFacts): CampaignCopy {
+  if (facts.eventType === "instore_published") {
+    return {
+      name: `Instore ${facts.artist}`,
+      goal: "Instore session links",
+      openingDmMessage: pickVariant(INSTORE_OPENINGS, facts.artist)(facts),
+      openingDmButtonLabel: "Watch",
+      dmMessage: pickVariant(REVEAL_VARIANTS, facts.artist),
+      linkButtonLabel: "YouTube",
+      trackedDestinationUrl: facts.youtubeUrl,
+      secondaryDestinationUrl: facts.soundcloudUrl,
+      secondaryButtonLabel: "SoundCloud",
+    };
+  }
+
+  const opening = pickVariant(RELEASE_OPENINGS[facts.eventType], facts.catno)(facts);
+
+  return {
+    name: `${facts.catno} ${RELEASE_GOALS[facts.eventType]}`,
+    goal: RELEASE_GOALS[facts.eventType],
+    openingDmMessage: opening,
+    openingDmButtonLabel: pickVariant(OPENING_BUTTON_VARIANTS, facts.catno),
+    dmMessage: pickVariant(REVEAL_VARIANTS, facts.catno),
+    linkButtonLabel:
+      facts.eventType === "preorder_open"
+        ? preorderButtonLabel(facts.catno)
+        : facts.catno.slice(0, META_BUTTON_LIMIT),
+    trackedDestinationUrl: facts.url,
+  };
+}

--- a/lib/meta/oauth.ts
+++ b/lib/meta/oauth.ts
@@ -7,6 +7,11 @@ import {
 } from "crypto";
 import { getEncryptionKeyHex, requireEnv } from "@/lib/env";
 
+const INSTAGRAM_OAUTH_SCOPE = [
+  "instagram_business_basic",
+  "instagram_business_manage_messages",
+  "instagram_business_manage_comments",
+].join(",");
 const INSTAGRAM_OAUTH_URL = "https://api.instagram.com/oauth/authorize";
 const INSTAGRAM_TOKEN_URL = "https://api.instagram.com/oauth/access_token";
 const ALGORITHM = "aes-256-gcm";
@@ -73,8 +78,13 @@ export function getAuthorizationUrl(redirectUri: string, state: string): string 
   const params = new URLSearchParams({
     client_id: requireEnv("INSTAGRAM_APP_ID"),
     redirect_uri: redirectUri,
-    scope:
-      "instagram_business_basic,instagram_business_manage_messages,instagram_business_manage_comments,instagram_business_manage_insights",
+    // instagram_business_manage_insights is deliberately absent: Meta refuses to
+    // add it to an app configured with Instagram Login (it is offered on the
+    // Facebook Login variant instead), and requesting an unconfigured scope
+    // fails the whole authorization. The overview route already degrades to
+    // insightsAvailable=false, so views/reach/saved/shares simply stay hidden.
+    // Re-add it here if Meta ever exposes it on the Instagram Login setup.
+    scope: INSTAGRAM_OAUTH_SCOPE,
     response_type: "code",
     state,
   });

--- a/lib/release-sync/shop-feed.ts
+++ b/lib/release-sync/shop-feed.ts
@@ -1,0 +1,116 @@
+/**
+ * Contract with the shop's release feed (yoyaku.io theme,
+ * GET /yoyaku/v1/release-events) and the pure derivation of typed events
+ * from stateless snapshots.
+ *
+ * The feed reports the CURRENT state of recent exclusive products; this
+ * module diffs it against the last state stored per SKU to derive the four
+ * events the pipeline reacts to. Keeping the derivation pure makes it
+ * testable without a database or network.
+ */
+
+import type { CampaignFacts } from "@/lib/copy/release-facts";
+
+export interface ShopProduct {
+  sku: string;
+  artist: string;
+  label: string;
+  title: string;
+  url: string;
+  stock_status: "onbackorder" | "instock" | "outofstock";
+  is_preorder: boolean;
+  published_gmt: string;
+}
+
+export interface ShopInstoreSession {
+  artist: string;
+  youtube_url: string;
+  soundcloud_url: string;
+  published_gmt: string;
+}
+
+export interface ShopFeed {
+  products: ShopProduct[];
+  instore: ShopInstoreSession[];
+}
+
+export interface DerivedEvent {
+  /** Dedup key — the SKU for releases, a slug of the artist for instore. */
+  sku: string;
+  facts: CampaignFacts;
+}
+
+function releaseFacts(
+  product: ShopProduct,
+  eventType: "preorder_open" | "release_live" | "restock"
+): CampaignFacts {
+  return {
+    eventType,
+    artist: product.artist,
+    title: product.title,
+    catno: product.sku,
+    label: product.label,
+    url: product.url,
+  };
+}
+
+/**
+ * State transitions:
+ * - unseen + onbackorder            -> preorder_open
+ * - unseen + instock                -> release_live (exclusive that skipped preorder)
+ * - onbackorder -> instock          -> release_live
+ * - outofstock -> instock           -> restock
+ * Anything else (unchanged status, going out of stock) derives nothing.
+ */
+export function deriveReleaseEvents(
+  products: ShopProduct[],
+  lastStatusBySku: Map<string, string>
+): DerivedEvent[] {
+  const events: DerivedEvent[] = [];
+
+  for (const product of products) {
+    const previous = lastStatusBySku.get(product.sku);
+    const current = product.stock_status;
+
+    if (previous === current) continue;
+
+    if (current === "onbackorder" && previous === undefined) {
+      events.push({ sku: product.sku, facts: releaseFacts(product, "preorder_open") });
+    } else if (current === "instock") {
+      if (previous === "outofstock") {
+        events.push({ sku: product.sku, facts: releaseFacts(product, "restock") });
+      } else {
+        // undefined or onbackorder
+        events.push({ sku: product.sku, facts: releaseFacts(product, "release_live") });
+      }
+    }
+  }
+
+  return events;
+}
+
+export function instoreDedupKey(artist: string): string {
+  return `instore:${artist.trim().toLowerCase().replace(/\s+/g, "-")}`;
+}
+
+export function deriveInstoreEvents(sessions: ShopInstoreSession[]): DerivedEvent[] {
+  return sessions.map((session) => ({
+    sku: instoreDedupKey(session.artist),
+    facts: {
+      eventType: "instore_published",
+      artist: session.artist,
+      youtubeUrl: session.youtube_url,
+      soundcloudUrl: session.soundcloud_url || "https://soundcloud.com/yoyaku",
+    },
+  }));
+}
+
+/** #TO001 in a caption, case-insensitive, not followed by more catno chars. */
+export function captionMatchesCatno(
+  caption: string | undefined,
+  catno: string
+): boolean {
+  if (!caption) return false;
+  const escaped = catno.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`#${escaped}(?![A-Za-z0-9])`, "i").test(caption);
+}

--- a/lib/workspace.ts
+++ b/lib/workspace.ts
@@ -68,6 +68,33 @@ export async function getWorkspaceMembership(userId: string): Promise<{
   };
 }
 
+/**
+ * Single-organization mode for self-hosted instances: instead of provisioning
+ * every new user their own empty OWNER workspace (upstream default, sensible
+ * for a SaaS), a colleague passing the domain allowlist joins the oldest
+ * existing workspace as MEMBER and immediately sees the connected Instagram
+ * accounts. Explicit invitations keep priority and their role. The very first
+ * user still creates the workspace and owns it.
+ */
+async function joinExistingWorkspaceIfConfigured(
+  userId: string
+): Promise<Workspace | null> {
+  if (process.env.AUTH_JOIN_EXISTING_WORKSPACE !== "true") return null;
+
+  const oldest = await prisma.workspace.findFirst({
+    orderBy: { createdAt: "asc" },
+  });
+  if (!oldest) return null;
+
+  await prisma.workspaceMember.upsert({
+    where: { workspaceId_userId: { workspaceId: oldest.id, userId } },
+    create: { workspaceId: oldest.id, userId, role: "MEMBER" },
+    update: {},
+  });
+
+  return oldest;
+}
+
 export async function ensureWorkspaceForUser(
   userId: string,
   email?: string | null
@@ -78,6 +105,9 @@ export async function ensureWorkspaceForUser(
   if (existingMembership) {
     return existingMembership.workspace;
   }
+
+  const joined = await joinExistingWorkspaceIfConfigured(userId);
+  if (joined) return joined;
 
   const workspaceName = email ? `${email.split("@")[0]}'s workspace` : "My workspace";
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,25 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "standalone",
+  poweredByHeader: false,
   reactCompiler: true,
+  reactStrictMode: true,
   turbopack: {
     root: process.cwd(),
+  },
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          {
+            key: "X-Accel-Buffering",
+            value: "no",
+          },
+        ],
+      },
+    ];
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,9 @@
         "tsx": "^4.22.1",
         "typescript": "^5",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=22.0.0 <23"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -52,9 +55,9 @@
       }
     },
     "node_modules/@auth/core": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.2.tgz",
-      "integrity": "sha512-Hx5MNBxN2fJTbJKGUKAA0wca43D0Akl3TvufY54Gn8lop7F+34vU1zA1pn0vQfIoVuLIrpfc2nkyjwIaPJMW7w==",
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.3.tgz",
+      "integrity": "sha512-sJ3JMHHkXMD3aOjopv7mOBTO1Ocw4b0fAEXJBz6k7YHLpYQI6C40jCUPc5fNvUKxXRXNE1/sRISA15UrwWJBTw==",
       "license": "ISC",
       "dependencies": {
         "@panva/hkdf": "^1.2.1",
@@ -66,7 +69,7 @@
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^7.0.7"
+        "nodemailer": "^7.0.7 || ^8.0.5"
       },
       "peerDependenciesMeta": {
         "@simplewebauthn/browser": {
@@ -81,25 +84,25 @@
       }
     },
     "node_modules/@auth/prisma-adapter": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.2.tgz",
-      "integrity": "sha512-GyNEUNtrPgDPs0M4xX6F5i7jTsCKwU6BXV9zutctcoo6K1Ud+juckrmQS11uyNgeWsw6sliextHbU/e+8lsizQ==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/@auth/prisma-adapter/-/prisma-adapter-2.11.3.tgz",
+      "integrity": "sha512-jZbpVAO6PTc9zNtdTWc0RLWG8qap4iMc54/3oWaWbuKdj92wHxzPrs3HivWB2mB9975GPW0l3YM/wFUWiUlTlg==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.2"
+        "@auth/core": "0.41.3"
       },
       "peerDependencies": {
         "@prisma/client": ">=2.26.0 || >=3 || >=4 || >=5 || >=6"
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -108,9 +111,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -118,21 +121,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -149,14 +152,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -166,14 +169,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -183,9 +186,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -193,29 +196,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -225,9 +228,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -235,9 +238,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -245,9 +248,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -255,27 +258,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -285,33 +288,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -319,65 +322,65 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
-      "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
+      "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
-      "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.3.tgz",
+      "integrity": "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
       },
       "peerDependencies": {
-        "@electric-sql/pglite": "0.4.1"
+        "@electric-sql/pglite": "0.4.3"
       }
     },
     "node_modules/@electric-sql/pglite-tools": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
-      "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.3.tgz",
+      "integrity": "sha512-AlzLJTRJ8+UFgK8CmxIpyIpJ0+YaFw02IiOSdYrqxwPXdSyeIShz8aa9Tq+tYFXdPwcaMp/Fc80mQZ1dkOQ/wg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@electric-sql/pglite": "0.4.1"
+        "@electric-sql/pglite": "0.4.3"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -385,9 +388,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -396,9 +399,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -413,9 +416,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -430,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -447,9 +450,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -464,9 +467,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -481,9 +484,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -498,9 +501,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -515,9 +518,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -532,9 +535,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -549,9 +552,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -566,9 +569,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -583,9 +586,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -600,9 +603,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -617,9 +620,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -634,9 +637,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -651,9 +654,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -668,9 +671,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -685,9 +688,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -702,9 +705,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -719,9 +722,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -736,9 +739,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -753,9 +756,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -770,9 +773,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -787,9 +790,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -804,9 +807,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -821,9 +824,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -981,19 +984,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.14.1"
-      },
-      "peerDependencies": {
-        "hono": "^4"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -1071,9 +1061,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.0.tgz",
+      "integrity": "sha512-ZgaYEwaj+lx/5n4W8GmZ2IYz0PQHjN5eqRcfijWGB+2Aq7ZInZGa0qJyAn6DEtyLuWHRSrmWOqT9q3qqTBvmUQ==",
       "cpu": [
         "arm64"
       ],
@@ -1083,19 +1073,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.0.tgz",
+      "integrity": "sha512-c1z9LFpKB0slQW3RchwBE8iSVzGp70TNjUUO9k4BZwwW4HH7JBGHeIy4b+kk4n/kcBASb9evKCE3/7Slmslgiw==",
       "cpu": [
         "x64"
       ],
@@ -1105,19 +1095,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.0"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.0.tgz",
+      "integrity": "sha512-Li2KTev0H90kEtnJHkI9xQojXt1AqWmFBMXiPw5kqd1jQgP7gi5HVK/qC5Rmh/59NuAwUuPzzPITmX22NomYYQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==",
       "cpu": [
         "arm64"
       ],
@@ -1131,9 +1140,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==",
       "cpu": [
         "x64"
       ],
@@ -1147,9 +1156,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.0.tgz",
+      "integrity": "sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==",
       "cpu": [
         "arm"
       ],
@@ -1163,9 +1172,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.0.tgz",
+      "integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
       "cpu": [
         "arm64"
       ],
@@ -1179,9 +1188,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.0.tgz",
+      "integrity": "sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==",
       "cpu": [
         "ppc64"
       ],
@@ -1195,9 +1204,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.0.tgz",
+      "integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
       "cpu": [
         "riscv64"
       ],
@@ -1211,9 +1220,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.0.tgz",
+      "integrity": "sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==",
       "cpu": [
         "s390x"
       ],
@@ -1227,9 +1236,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.0.tgz",
+      "integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
       "cpu": [
         "x64"
       ],
@@ -1243,9 +1252,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.0.tgz",
+      "integrity": "sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==",
       "cpu": [
         "arm64"
       ],
@@ -1259,9 +1268,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.0.tgz",
+      "integrity": "sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==",
       "cpu": [
         "x64"
       ],
@@ -1275,9 +1284,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.0.tgz",
+      "integrity": "sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==",
       "cpu": [
         "arm"
       ],
@@ -1287,19 +1296,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.0.tgz",
+      "integrity": "sha512-4+4XHLNT5wDT0roYlHTEmH9lDKt0acf9Tv+3hM3iceOirkxrR404/3WjAYZ9F9CkHrxeRcGLJXbi4vluMZ9O+A==",
       "cpu": [
         "arm64"
       ],
@@ -1309,19 +1318,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.0.tgz",
+      "integrity": "sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==",
       "cpu": [
         "ppc64"
       ],
@@ -1331,19 +1340,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.0.tgz",
+      "integrity": "sha512-l6vmKVPnbS0RhVMbyxP5meAARsbhCnBN4fy31qz0+3a6Rv4jEqfzDrT89y6ZPkCi0AJGnwp2En528yXo401Hpw==",
       "cpu": [
         "riscv64"
       ],
@@ -1353,19 +1362,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.0.tgz",
+      "integrity": "sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==",
       "cpu": [
         "s390x"
       ],
@@ -1375,19 +1384,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.0.tgz",
+      "integrity": "sha512-TYaItB5oj1ioXjhyn2xrR208vf+YuIIcHptQWRRaBmFhvIvL9D72DXN8w75xup0KXA8UdEAhQ9Qb2S49FD/9Cw==",
       "cpu": [
         "x64"
       ],
@@ -1397,19 +1406,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.0.tgz",
+      "integrity": "sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==",
       "cpu": [
         "arm64"
       ],
@@ -1419,19 +1428,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.0.tgz",
+      "integrity": "sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==",
       "cpu": [
         "x64"
       ],
@@ -1441,38 +1450,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.0.tgz",
+      "integrity": "sha512-9woLIFORERCr+6cWu87dQ22J34EExkhc73U1kZW0c+RclQqWetoodByp4dWZ/hN8/KVmTRAx2HOnUwib8AwZdA==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.0"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.0.tgz",
+      "integrity": "sha512-t+kie1TOyaDM6Dho+f+y0VqIUNhYQaKCUahuZVi0E0frgdiaOaPsDxDW3wfKacUdaNBCnK/ZDBMg33ydvHj8uA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.0.tgz",
+      "integrity": "sha512-M5eKxug0dabbaWgFKvPa3odNs2OpaP+81NASfGKkt4GcYXpNhSu7CaeYxWkLNV6vHmUp4hnCxnxrUyhUJhXbKA==",
       "cpu": [
         "arm64"
       ],
@@ -1482,16 +1507,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.0.tgz",
+      "integrity": "sha512-z0+pZ03QCDvdVN0Ez9IX/yjWC19ikMlXrmdYMwYNLTh2BLPx3hXWPvyqWfquZ0BTO9O6GVOjIVoTcyyacMnWlQ==",
       "cpu": [
         "ia32"
       ],
@@ -1501,16 +1526,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.0.tgz",
+      "integrity": "sha512-feNnlz5ZHKr0MY1LPHvZQyJeBkbo4ctsn0D8FvA53VTw5TC63rfEL2UrWbkSBR19htSE7Mw78xYVwdJqoMWVHw==",
       "cpu": [
         "x64"
       ],
@@ -1520,7 +1545,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1581,13 +1606,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
@@ -1681,9 +1699,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
-      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1697,9 +1715,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
-      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1713,9 +1731,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
-      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1729,9 +1747,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
-      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
       ],
@@ -1745,9 +1763,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
-      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
       ],
@@ -1761,9 +1779,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
-      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
       ],
@@ -1777,9 +1795,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
-      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
       ],
@@ -1793,9 +1811,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
-      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1809,9 +1827,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
-      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -1873,9 +1891,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1934,9 +1952,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.8.0.tgz",
-      "integrity": "sha512-HFESzd9rx2ZQxlK+TL7tu1HPvCqrHiL6LCxYykI2c34mvaUuIVVl3lYuicJD/MNnzgPnyeBEMlK4WTomJCV5jw==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.1.tgz",
+      "integrity": "sha512-4znKhxTmXmuPye9Z6pbIyYb5VZlkZ05qG1L6Dr4g+7oTwc6V50Bs9XirFBDdjWt+H/AabMn9aUnxBcvj8z05aA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1953,28 +1971,26 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/dev": {
-      "version": "0.24.3",
-      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
-      "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
+      "version": "0.24.17",
+      "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.17.tgz",
+      "integrity": "sha512-UvdZzmpFwknnfreh6Jije84ekkYGPYEJhXG1tFzCsCfQyzJifrOo38eZc0qajzvaC6OLUOrN9ML5XfCnEZL9DA==",
       "devOptional": true,
       "license": "ISC",
       "dependencies": {
-        "@electric-sql/pglite": "0.4.1",
-        "@electric-sql/pglite-socket": "0.1.1",
-        "@electric-sql/pglite-tools": "0.3.1",
-        "@hono/node-server": "1.19.11",
+        "@electric-sql/pglite": "0.4.3",
+        "@electric-sql/pglite-socket": "0.1.3",
+        "@electric-sql/pglite-tools": "0.3.3",
         "@prisma/get-platform": "7.2.0",
         "@prisma/query-plan-executor": "7.2.0",
-        "@prisma/streams-local": "0.1.2",
+        "@prisma/streams-local": "0.1.11",
+        "find-my-way": "9.7.0",
         "foreground-child": "3.3.1",
         "get-port-please": "3.2.0",
-        "hono": "^4.12.8",
-        "http-status-codes": "2.3.0",
         "pathe": "2.0.3",
         "proper-lockfile": "4.1.2",
         "remeda": "2.33.4",
         "std-env": "3.10.0",
-        "valibot": "1.2.0",
+        "valibot": "1.4.2",
         "zeptomatch": "2.1.0"
       }
     },
@@ -1988,56 +2004,70 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.8.0.tgz",
-      "integrity": "sha512-jx3rCnNNrt5uzbkKlegtQ2GZHxSlihMCzutgT/BP6UIDF1r9tDI39hV/0T/cHZgzJ3ELbuQPXlVZy+Y1n0pcgw==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.1.tgz",
+      "integrity": "sha512-UprXSMNXx2NF5ow4pqaQtE8OuBz6K78B0wc0tn2L28G5r933iWp1DR9Do2qWrsNvvFIP3x6mpEWnQtckMO0Uhg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.8.0",
-        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
-        "@prisma/fetch-engine": "7.8.0",
-        "@prisma/get-platform": "7.8.0"
+        "@prisma/debug": "7.9.1",
+        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+        "@prisma/fetch-engine": "7.9.1",
+        "@prisma/get-platform": "7.9.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a.tgz",
-      "integrity": "sha512-fJPQxCkLgA5EayWaW8eArgCvjJ+N+Kz3VyeNKMEeYiQC4alNkxRKFVAGxv/ZUzuJISKqdw+zGeDbS6mn6RCPOA==",
+      "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
+      "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
+      "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
-      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
+      "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.8.0"
+        "@prisma/debug": "7.9.1"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.8.0.tgz",
-      "integrity": "sha512-gwB0Euiz/DDRyxFRpLXYlK3RfaZUj1c5dAYMuhZYfApg7arknJlcb9bIsOHDppJmbqYaVA+yBIiFMDBfprsNPQ==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.1.tgz",
+      "integrity": "sha512-9DwxrNTeT25Orbu9CWh0CZvVlyY1lmscpbaeLZcOnuR7zcuFrt91YSmmOfIm7zJ08YOZ6mVzURKwLoMwEBcK8w==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.8.0",
-        "@prisma/engines-version": "7.8.0-6.3c6e192761c0362d496ed980de936e2f3cebcd3a",
-        "@prisma/get-platform": "7.8.0"
+        "@prisma/debug": "7.9.1",
+        "@prisma/engines-version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
+        "@prisma/get-platform": "7.9.1"
       }
     },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
+      "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.8.0.tgz",
-      "integrity": "sha512-WlxgRGnolL8VH2EmkH1R/DkKNr/mVdS3G2h42IZFFZ3eUrH9OT6t73kIOSlkkrv50wG123Iq8d96ufv5LlZktw==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
+      "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.8.0"
+        "@prisma/debug": "7.9.1"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -2065,9 +2095,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/streams-local": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
-      "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.11.tgz",
+      "integrity": "sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2077,7 +2107,7 @@
         "proper-lockfile": "^4.1.2"
       },
       "engines": {
-        "bun": ">=1.3.6",
+        "bun": ">=1.2.0",
         "node": ">=22.0.0"
       }
     },
@@ -2106,14 +2136,23 @@
       "license": "MIT"
     },
     "node_modules/@prisma/studio-core": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
-      "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.33.0.tgz",
+      "integrity": "sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-toggle": "1.1.10",
-        "chart.js": "4.5.1"
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/event": "4.0.1-alpha.0",
+        "@visx/grid": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/responsive": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/shape": "4.0.1-alpha.0",
+        "d3-array": "3.2.4",
+        "d3-shape": "3.2.0",
+        "elkjs": "0.11.1"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0",
@@ -2309,9 +2348,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
@@ -2326,9 +2365,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
@@ -2343,9 +2382,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
@@ -2360,9 +2399,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
@@ -2377,9 +2416,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
@@ -2394,9 +2433,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
@@ -2411,9 +2450,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
@@ -2428,9 +2467,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
@@ -2445,9 +2484,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
@@ -2462,9 +2501,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
@@ -2479,9 +2518,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
@@ -2496,9 +2535,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
@@ -2513,9 +2552,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
       "cpu": [
         "wasm32"
       ],
@@ -2523,37 +2562,40 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.1.tgz",
+      "integrity": "sha512-KjZdi8Q1wh89gsVmghvbrMgWl6ZWmRmHV6wjB7/g4Zf0dyO+hH3neZUtuDNPO00qq5YE5RITVWvrIZKRaAmzGQ==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
@@ -2568,9 +2610,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
@@ -2585,9 +2627,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2891,9 +2933,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2924,11 +2966,35 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
@@ -2969,6 +3035,13 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
+      "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
@@ -2989,6 +3062,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3001,6 +3081,13 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
+      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3037,7 +3124,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3235,29 +3322,6 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3653,6 +3717,218 @@
         "vue-router": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@visx/curve": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "4.0.0-alpha.0"
+      }
+    },
+    "node_modules/@visx/event": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/event/-/event-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/point": "4.0.1-alpha.0"
+      }
+    },
+    "node_modules/@visx/grid": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/point": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/shape": "4.0.1-alpha.0",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/group": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/group/-/group-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/point": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/point/-/point-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@visx/responsive": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.13",
+        "@types/react": "*",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/scale": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "4.0.0-alpha.0"
+      }
+    },
+    "node_modules/@visx/shape": {
+      "version": "4.0.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-4.0.1-alpha.0.tgz",
+      "integrity": "sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/lodash": "^4.17.13",
+        "@types/react": "*",
+        "@visx/curve": "4.0.1-alpha.0",
+        "@visx/group": "4.0.1-alpha.0",
+        "@visx/scale": "4.0.1-alpha.0",
+        "@visx/vendor": "4.0.0-alpha.0",
+        "classnames": "^2.3.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0-0 || ^18.0.0-0 || ^19.0.0-0"
+      }
+    },
+    "node_modules/@visx/vendor": {
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==",
+      "devOptional": true,
+      "license": "MIT and ISC",
+      "dependencies": {
+        "@types/d3-array": "3.0.3",
+        "@types/d3-color": "3.1.0",
+        "@types/d3-delaunay": "6.0.1",
+        "@types/d3-format": "3.0.1",
+        "@types/d3-geo": "3.1.0",
+        "@types/d3-interpolate": "3.0.1",
+        "@types/d3-path": "3.1.1",
+        "@types/d3-scale": "4.0.2",
+        "@types/d3-shape": "3.1.7",
+        "@types/d3-time": "3.0.0",
+        "@types/d3-time-format": "2.1.0",
+        "d3-array": "3.2.1",
+        "d3-color": "3.1.0",
+        "d3-delaunay": "6.0.2",
+        "d3-format": "3.1.0",
+        "d3-geo": "3.1.0",
+        "d3-interpolate": "3.0.1",
+        "d3-path": "3.1.0",
+        "d3-scale": "4.0.2",
+        "d3-shape": "3.2.0",
+        "d3-time": "3.1.0",
+        "d3-time-format": "4.1.0",
+        "internmap": "2.0.3"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/@types/d3-array": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
+      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@visx/vendor/node_modules/@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@visx/vendor/node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/@types/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@visx/vendor/node_modules/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@visx/vendor/node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "devOptional": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@vitest/expect": {
@@ -4085,16 +4361,19 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.7.tgz",
+      "integrity": "sha512-APw5YuIQAg6L9w4sHDI6j26DGFJI6RpYOhnkMPdC9lWbkKvsyPHzDsve1yd73lk21yz7Y09Kci8B2Pp9FonzWA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -4104,21 +4383,23 @@
       }
     },
     "node_modules/better-result": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.9.0.tgz",
-      "integrity": "sha512-NHwGDGVbRlWDOce3CwcfGIrcNR9zY37ut3SVwQVfv57DZdVhxjhA4mfaHN1n8QwWnRAR4iErpW1X/eaiaUaFYg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.10.0.tgz",
+      "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4135,9 +4416,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -4155,10 +4436,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -4287,9 +4568,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "funding": [
         {
           "type": "opencollective",
@@ -4333,19 +4614,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
@@ -4361,6 +4629,13 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -4482,6 +4757,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -4496,6 +4784,19 @@
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
       "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -4726,6 +5027,16 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
     "node_modules/denque": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
@@ -4805,11 +5116,18 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.344",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "version": "1.5.398",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.398.tgz",
+      "integrity": "sha512-AsvhAxopJGh6museTDMIjn6JpDYOfgu4RLlygomt87MUwBUqTfd/1EiPtx10/LZE8xpTvkP2E9Gafq7lkLtodQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "devOptional": true,
+      "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5050,9 +5368,9 @@
       ]
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5063,32 +5381,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -5547,9 +5865,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -5575,6 +5893,13 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -5627,10 +5952,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "devOptional": true,
       "funding": [
         {
@@ -5678,6 +6013,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -5915,9 +6265,9 @@
       }
     },
     "node_modules/giget": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-3.2.0.tgz",
-      "integrity": "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -5988,9 +6338,9 @@
       "license": "ISC"
     },
     "node_modules/grammex": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.12.tgz",
-      "integrity": "sha512-6ufJOsSA7LcQehIJNCO7HIBykfM7DXQual0Ny780/DEcJIpBlHRvcqEBWGPYd7hrXL2GJ3oJI1MIhaXjWmLQOQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.13.tgz",
+      "integrity": "sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6111,23 +6461,6 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
-    },
-    "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.9.0"
-      }
-    },
-    "node_modules/http-status-codes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.3.0.tgz",
-      "integrity": "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA==",
-      "devOptional": true,
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -6706,9 +7039,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
-      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.5.tgz",
+      "integrity": "sha512-2E5L2yRp03FnwreJLJX8/r7mHiZICCf8kG7fAsTWkSQTDAcc46NIZoQLKy+EJ8sPoJlxyS4OQR5H70LjIZZlIQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -6722,10 +7055,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -7118,6 +7461,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -7249,6 +7599,24 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -7331,9 +7699,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7372,12 +7740,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
-      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.6",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -7391,14 +7759,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.6",
-        "@next/swc-darwin-x64": "16.2.6",
-        "@next/swc-linux-arm64-gnu": "16.2.6",
-        "@next/swc-linux-arm64-musl": "16.2.6",
-        "@next/swc-linux-x64-gnu": "16.2.6",
-        "@next/swc-linux-x64-musl": "16.2.6",
-        "@next/swc-win32-arm64-msvc": "16.2.6",
-        "@next/swc-win32-x64-msvc": "16.2.6",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -7425,18 +7793,18 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.31",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.31.tgz",
-      "integrity": "sha512-1OBgCKPzo+S7UWWMp3xgvGvIJ0OpV7B3vR4ZDRqD9a4Ch+OT6dakLXG9ivhtmIWVa71nTSXattOHyCg8sNi8/Q==",
+      "version": "5.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.32.tgz",
+      "integrity": "sha512-CGlChIEWZ6LltNVxrE5yiySMID+Idpmry47JYA5lLwgD8Sx02a8M65VL0TWVz9nbnOioS/tCW/rP/0+mE7Qp4Q==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.2"
+        "@auth/core": "0.41.3"
       },
       "peerDependencies": {
         "@simplewebauthn/browser": "^9.0.1",
         "@simplewebauthn/server": "^9.0.2",
         "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
-        "nodemailer": "^7.0.7",
+        "nodemailer": "^7.0.7 || ^8.0.5",
         "react": "^18.2.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -7449,34 +7817,6 @@
         "nodemailer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-abort-controller": {
@@ -7520,11 +7860,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/oauth4webapi": {
       "version": "3.8.6",
@@ -7938,10 +8281,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
-      "dev": true,
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7958,7 +8300,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8049,17 +8391,17 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.8.0.tgz",
-      "integrity": "sha512-yfN4yrw7HV9kEJhoy1+jgah0jafEIQsf7uWouSsM8MvJtlubsk+kM7AIBWZ8+GJl74Yj3c+nbYqBkMOxtsZ3Lw==",
+      "version": "7.9.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.1.tgz",
+      "integrity": "sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.8.0",
-        "@prisma/dev": "0.24.3",
-        "@prisma/engines": "7.8.0",
-        "@prisma/studio-core": "0.27.3",
+        "@prisma/config": "7.9.1",
+        "@prisma/dev": "0.24.17",
+        "@prisma/engines": "7.9.1",
+        "@prisma/studio-core": "0.33.0",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
       },
@@ -8416,6 +8758,16 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -8437,15 +8789,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "devOptional": true,
+      "license": "Unlicense"
+    },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -8454,21 +8813,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/run-parallel": {
@@ -8550,6 +8909,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8629,54 +9011,54 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.0.tgz",
+      "integrity": "sha512-BqvG5XbwPZ4NV0DK90d86leEECMsoa8bO0nqnKWlBDYxri4GJ7c4EDInaF6q20lTh/mATmnDIKWJFfXnoVfH5g==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.4"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.0",
+        "@img/sharp-darwin-x64": "0.35.0",
+        "@img/sharp-freebsd-wasm32": "0.35.0",
+        "@img/sharp-libvips-darwin-arm64": "1.3.0",
+        "@img/sharp-libvips-darwin-x64": "1.3.0",
+        "@img/sharp-libvips-linux-arm": "1.3.0",
+        "@img/sharp-libvips-linux-arm64": "1.3.0",
+        "@img/sharp-libvips-linux-ppc64": "1.3.0",
+        "@img/sharp-libvips-linux-riscv64": "1.3.0",
+        "@img/sharp-libvips-linux-s390x": "1.3.0",
+        "@img/sharp-libvips-linux-x64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.0",
+        "@img/sharp-linux-arm": "0.35.0",
+        "@img/sharp-linux-arm64": "0.35.0",
+        "@img/sharp-linux-ppc64": "0.35.0",
+        "@img/sharp-linux-riscv64": "0.35.0",
+        "@img/sharp-linux-s390x": "0.35.0",
+        "@img/sharp-linux-x64": "0.35.0",
+        "@img/sharp-linuxmusl-arm64": "0.35.0",
+        "@img/sharp-linuxmusl-x64": "0.35.0",
+        "@img/sharp-webcontainers-wasm32": "0.35.0",
+        "@img/sharp-win32-arm64": "0.35.0",
+        "@img/sharp-win32-ia32": "0.35.0",
+        "@img/sharp-win32-x64": "0.35.0"
       }
     },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -9104,9 +9486,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9478,9 +9860,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
-      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
@@ -9515,17 +9897,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
-        "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9541,7 +9923,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.3.0",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -9593,9 +9975,9 @@
       }
     },
     "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,9 +17,11 @@
         "next": "^16.2.6",
         "next-auth": "^5.0.0-beta.31",
         "pg": "^8.20.0",
+        "prisma": "^7.8.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "recharts": "^3.8.1",
+        "tsx": "^4.22.1",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -31,9 +33,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9",
         "eslint-config-next": "^16.2.6",
-        "prisma": "^7.8.0",
         "tailwindcss": "^4",
-        "tsx": "^4.22.1",
         "typescript": "^5",
         "vitest": "^4.1.5"
       },
@@ -339,14 +339,12 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.3.tgz",
       "integrity": "sha512-ichuWTgtd4mOM1G4SpyGJa5trT03lWbMypDV0fUXUCXg5hiHqVAz/bZyV68NqmkLB7WcYmj1RMJVSp8HV/v/ZQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@electric-sql/pglite-socket": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.3.tgz",
       "integrity": "sha512-LAciWM0M1dCL8hlsxu2venbVZcdxema0BtDfpWYVqr+Y468UADw0pFWidhKw1M8sfJ8rdLT71tjMmnirf/IZRQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "pglite-server": "dist/scripts/server.js"
@@ -359,7 +357,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.3.tgz",
       "integrity": "sha512-AlzLJTRJ8+UFgK8CmxIpyIpJ0+YaFw02IiOSdYrqxwPXdSyeIShz8aa9Tq+tYFXdPwcaMp/Fc80mQZ1dkOQ/wg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "peerDependencies": {
         "@electric-sql/pglite": "0.4.3"
@@ -405,7 +402,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -422,7 +418,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -439,7 +434,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -456,7 +450,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -473,7 +466,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -490,7 +482,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -507,7 +498,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -524,7 +514,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -541,7 +530,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -558,7 +546,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -575,7 +562,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -592,7 +578,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -609,7 +594,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -626,7 +610,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -643,7 +626,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -660,7 +642,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,7 +658,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -694,7 +674,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -711,7 +690,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -728,7 +706,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -745,7 +722,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -762,7 +738,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -779,7 +754,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -796,7 +770,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -813,7 +786,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -830,7 +802,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1926,6 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.9.1.tgz",
       "integrity": "sha512-4znKhxTmXmuPye9Z6pbIyYb5VZlkZ05qG1L6Dr4g+7oTwc6V50Bs9XirFBDdjWt+H/AabMn9aUnxBcvj8z05aA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "c12": "3.3.4",
@@ -1974,7 +1944,6 @@
       "version": "0.24.17",
       "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.17.tgz",
       "integrity": "sha512-UvdZzmpFwknnfreh6Jije84ekkYGPYEJhXG1tFzCsCfQyzJifrOo38eZc0qajzvaC6OLUOrN9ML5XfCnEZL9DA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@electric-sql/pglite": "0.4.3",
@@ -2007,7 +1976,6 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.9.1.tgz",
       "integrity": "sha512-UprXSMNXx2NF5ow4pqaQtE8OuBz6K78B0wc0tn2L28G5r933iWp1DR9Do2qWrsNvvFIP3x6mpEWnQtckMO0Uhg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2021,21 +1989,18 @@
       "version": "7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.9.0-1.e922089b7d7502aff4249d5da3420f6fa55fc6ad.tgz",
       "integrity": "sha512-2BsPPFksz3CQUXG6af3rVCtJKg6+JJGJTtfgu2fU8DdXhOfkBjulCq8mwybCd6ge0/jhZq2kOtLAbmUDMyI1nA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/debug": {
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
       "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
       "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.9.1"
@@ -2045,7 +2010,6 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.9.1.tgz",
       "integrity": "sha512-9DwxrNTeT25Orbu9CWh0CZvVlyY1lmscpbaeLZcOnuR7zcuFrt91YSmmOfIm7zJ08YOZ6mVzURKwLoMwEBcK8w==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.9.1",
@@ -2057,14 +2021,12 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.9.1.tgz",
       "integrity": "sha512-/cpVZ4itxtcgB8GHBvZtcmuEjq+lWsLrRJxFMbwZrT1RIdtuKmUm7PPGo/wzfbYpBrk+9WmmBE8CHJw2rybKDQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.9.1.tgz",
       "integrity": "sha512-PK8R60YZRQvYxBrGG9i7l2/rFyzy+2MuI1dKtmtrCqPH8YpiJx/MfiC7LRzX5786rZDEv7BngcjfIJW4/9ADuw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.9.1"
@@ -2074,7 +2036,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.2.0.tgz",
       "integrity": "sha512-k1V0l0Td1732EHpAfi2eySTezyllok9dXb6UQanajkJQzPUGi3vO2z7jdkz67SypFTdmbnyGYxvEvYZdZsMAVA==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "7.2.0"
@@ -2084,21 +2045,18 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.2.0.tgz",
       "integrity": "sha512-YSGTiSlBAVJPzX4ONZmMotL+ozJwQjRmZweQNIq/ER0tQJKJynNkRB3kyvt37eOfsbMCXk3gnLF6J9OJ4QWftw==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/query-plan-executor": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@prisma/query-plan-executor/-/query-plan-executor-7.2.0.tgz",
       "integrity": "sha512-EOZmNzcV8uJ0mae3DhTsiHgoNCuu1J9mULQpGCh62zN3PxPTd+qI9tJvk5jOst8WHKQNwJWR3b39t0XvfBB0WQ==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/streams-local": {
       "version": "0.1.11",
       "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.11.tgz",
       "integrity": "sha512-0TcebL559MByKqTJ+SsrFIEg228iw8UCVRFckzgfRSiJqczhs+MuAgWOF9lnOIV/IVqvu+KMnFTH0eDeTQMpUg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.12.0",
@@ -2115,7 +2073,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -2132,14 +2089,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@prisma/studio-core": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.33.0.tgz",
       "integrity": "sha512-V2fX/nKEymNTrHXwfP26PGjoLStO35Ogu+ex7CFJbLrMYEcZxxZpiSNOs7px23Hk5mzLWvM5RsqG6Ka+rha+wg==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@radix-ui/react-toggle": "1.1.10",
@@ -2168,14 +2123,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2191,7 +2144,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
@@ -2215,7 +2167,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -2234,7 +2185,6 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
       "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2260,7 +2210,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
       "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-effect-event": "0.0.2",
@@ -2280,7 +2229,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
       "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -2299,7 +2247,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2884,6 +2831,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -2970,7 +2981,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
       "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-ease": {
@@ -2983,14 +2993,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
       "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-geo": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
       "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
@@ -3039,7 +3047,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.1.0.tgz",
       "integrity": "sha512-/myT3I7EwlukNOX2xVdMzb8FRgNzRMpsZddwst9Ld/VFe6LyJyRp0s32l/V9XoUzk+Gqu56F/oGk6507+8BxrA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/d3-timer": {
@@ -3066,7 +3073,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -3087,7 +3093,6 @@
       "version": "4.17.24",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
       "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3114,7 +3119,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3124,7 +3128,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -3723,7 +3727,6 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/curve/-/curve-4.0.1-alpha.0.tgz",
       "integrity": "sha512-jRu61Uz274pV1zyioXmboyrLutYbnKsgjj4njSGCnhdXj5GkZvZbg+ThDb6oOzoAnJOBRLz4rzPlWvNJOzuVMg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@visx/vendor": "4.0.0-alpha.0"
@@ -3733,7 +3736,6 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/event/-/event-4.0.1-alpha.0.tgz",
       "integrity": "sha512-EQqCMSv/s8NbFjo+hz3FKsvvYfP+2QslsFJ/24/O5l/W+7UC6J6aAvO0ujVwrTwdYbuQ+vhxKi1xdPdKR/qj1g==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*",
@@ -3744,7 +3746,6 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/grid/-/grid-4.0.1-alpha.0.tgz",
       "integrity": "sha512-rycutGmTHO+znNdPumheWMglm7YfpffvRwUkVy5zy4WoORIuKTMkDxwnOzHG2xMxU3EE/YCd37xFV5AxA30yeg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*",
@@ -3763,7 +3764,6 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/group/-/group-4.0.1-alpha.0.tgz",
       "integrity": "sha512-V19l7iQ7jccBv8kao/EByuI6o4xtxzzLV9nqVI1hRvmdzTVsuLpqlwzYCZUXJaTVvUWf8s4D2SQFjGkj/Nw+0w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*",
@@ -3777,14 +3777,12 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/point/-/point-4.0.1-alpha.0.tgz",
       "integrity": "sha512-ijTfr/Nx09f03vIj9nyTr3z4Xth4Y75427UaogJh6dnIRLMEFHQOwNu791sbfiNj0a+ZXuaE32h0vKrFe4/8Qg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@visx/responsive": {
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/responsive/-/responsive-4.0.1-alpha.0.tgz",
       "integrity": "sha512-o+1zGywQZY0+yOx3Iw87wc4bbPJRr/HnIukTwfOz4UVyj9pB1OQNVHB7OORO1+LBHJceWpB31co/ZV9KHncKrA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.13",
@@ -3799,7 +3797,6 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-4.0.1-alpha.0.tgz",
       "integrity": "sha512-nzjeE87vFSAXGWFiiNfBpNLAf0Q8Qmf6syvKLjqNi4kGZkdhbUll3E/59YsgWXmjM8+llPLWzGsP+JPvo5eq1A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@visx/vendor": "4.0.0-alpha.0"
@@ -3809,7 +3806,6 @@
       "version": "4.0.1-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/shape/-/shape-4.0.1-alpha.0.tgz",
       "integrity": "sha512-62QeiVNmPlterQGwhkEDcbq7M0MqY0lBsK5QKXtM9ZoPZWkuGV3aykA3+Xu20B2FAvyJq4LqJzBc7Sxr+EAdbA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "^4.17.13",
@@ -3829,7 +3825,6 @@
       "version": "4.0.0-alpha.0",
       "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-4.0.0-alpha.0.tgz",
       "integrity": "sha512-6I+MuqXBcv9jnlcVowHoHKSdk9gXTWkHLKyqBwRWg7LY6A3Ei8SHfubpqGV5rBUSppxMq2RszPJUS6w+H0YgmQ==",
-      "devOptional": true,
       "license": "MIT and ISC",
       "dependencies": {
         "@types/d3-array": "3.0.3",
@@ -3861,21 +3856,18 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
       "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@visx/vendor/node_modules/@types/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@visx/vendor/node_modules/@types/d3-interpolate": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
       "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-color": "*"
@@ -3885,7 +3877,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
       "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-time": "*"
@@ -3895,7 +3886,6 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
       "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/d3-path": "*"
@@ -3905,14 +3895,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
       "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@visx/vendor/node_modules/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
       "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
@@ -3925,7 +3913,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -4324,7 +4311,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
       "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0"
@@ -4386,7 +4372,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.10.0.tgz",
       "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -4482,7 +4467,6 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
       "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -4618,7 +4602,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -4634,7 +4617,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/client-only": {
@@ -4692,7 +4674,6 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/convert-source-map": {
@@ -4718,7 +4699,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4733,7 +4713,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -4761,7 +4740,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
       "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "delaunator": "5"
@@ -4792,7 +4770,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
       "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "d3-array": "2.5.0 - 3"
@@ -4978,7 +4955,6 @@
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
       "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
@@ -5024,14 +5000,12 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delaunator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
       "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "robust-predicates": "^3.0.2"
@@ -5050,7 +5024,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
       "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -5080,7 +5053,6 @@
       "version": "17.4.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
-      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5108,7 +5080,6 @@
       "version": "3.20.0",
       "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
       "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -5126,7 +5097,6 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
       "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
-      "devOptional": true,
       "license": "EPL-2.0"
     },
     "node_modules/emoji-regex": {
@@ -5140,7 +5110,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
       "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5164,7 +5133,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
       "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -5371,7 +5339,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -5868,14 +5835,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
       "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-check": {
       "version": "3.23.2",
       "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
       "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -5898,14 +5863,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5956,7 +5919,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
@@ -5966,7 +5928,6 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6019,7 +5980,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
       "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -6088,7 +6048,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -6105,7 +6064,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6161,7 +6119,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-property": "^1.0.2"
@@ -6216,7 +6173,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.2.0.tgz",
       "integrity": "sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/get-proto": {
@@ -6268,7 +6224,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
       "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "giget": "dist/cli.mjs"
@@ -6334,21 +6289,18 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/grammex": {
       "version": "3.1.13",
       "resolved": "https://registry.npmjs.org/grammex/-/grammex-3.1.13.tgz",
       "integrity": "sha512-LnPnhOBLEJEVKS8WFDVaA397L9Kq55Q9oSITJiVLHVdhAclfUkWzQv74KhvZHKL2Q09Pb1XdsrOsZ4LfTFFTEg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/graphmatch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
       "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/has-bigints": {
@@ -6466,7 +6418,6 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
       "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6848,7 +6799,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -7007,7 +6957,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -7032,7 +6981,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7465,7 +7413,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -7491,7 +7438,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
@@ -7521,7 +7467,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
       "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1.0.0",
@@ -7668,7 +7613,6 @@
       "version": "3.15.3",
       "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.15.3.tgz",
       "integrity": "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "aws-ssl-profiles": "^1.1.1",
@@ -7689,7 +7633,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
       "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lru.min": "^1.1.0"
@@ -8016,7 +7959,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -8114,7 +8056,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8131,14 +8072,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/perfect-debounce": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-2.1.0.tgz",
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -8262,7 +8201,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
       "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "confbox": "^0.2.4",
@@ -8312,7 +8250,6 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
-      "devOptional": true,
       "license": "Unlicense",
       "engines": {
         "node": ">=12"
@@ -8394,7 +8331,6 @@
       "version": "7.9.1",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.9.1.tgz",
       "integrity": "sha512-aPqePoZIqwlAchbgbFDO/wHqGB+7H1nj9gaM+OsL9h77S5S3TnLd9BgD3LnoeDikULo7cl2HSUrEyQ55Z7DYbg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8440,7 +8376,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
       "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8452,7 +8387,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/punycode": {
@@ -8469,7 +8403,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -8507,7 +8440,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
       "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "defu": "^6.1.6",
@@ -8568,7 +8500,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -8692,7 +8623,6 @@
       "version": "2.33.4",
       "resolved": "https://registry.npmjs.org/remeda/-/remeda-2.33.4.tgz",
       "integrity": "sha512-ygHswjlc/opg2VrtiYvUOPLjxjtdKvjGz1/plDhkG66hjNjFr1xmfrs2ClNFo/E6TyUFiwYNh53bKV26oBoMGQ==",
-      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/remeda"
@@ -8702,7 +8632,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8762,7 +8691,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
       "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8772,7 +8700,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -8793,7 +8720,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
       "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-      "devOptional": true,
       "license": "Unlicense"
     },
     "node_modules/rolldown": {
@@ -8913,7 +8839,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
       "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -8936,7 +8861,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -8958,8 +8882,7 @@
     "node_modules/seq-queue": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==",
-      "devOptional": true
+      "integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9072,7 +8995,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9085,7 +9007,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9178,7 +9099,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -9209,7 +9129,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
       "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9239,7 +9158,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -9605,7 +9523,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.1.tgz",
       "integrity": "sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -9863,7 +9780,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
       "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
-      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -10101,7 +10017,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10262,7 +10177,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/zeptomatch/-/zeptomatch-2.1.0.tgz",
       "integrity": "sha512-KiGErG2J0G82LSpniV0CtIzjlJ10E04j02VOudJsPyPwNZgGnRKQy7I1R7GMyg/QswnE4l7ohSGrQbQbjXPPDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "grammex": "^3.1.11",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "openreply",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.0.0 <23"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",
@@ -43,5 +46,9 @@
     "tsx": "^4.22.1",
     "typescript": "^5",
     "vitest": "^4.1.5"
+  },
+  "overrides": {
+    "postcss": "8.5.25",
+    "sharp": "0.35.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
     "next": "^16.2.6",
     "next-auth": "^5.0.0-beta.31",
     "pg": "^8.20.0",
+    "prisma": "^7.8.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "recharts": "^3.8.1",
+    "tsx": "^4.22.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -41,9 +43,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
     "eslint-config-next": "^16.2.6",
-    "prisma": "^7.8.0",
     "tailwindcss": "^4",
-    "tsx": "^4.22.1",
     "typescript": "^5",
     "vitest": "^4.1.5"
   },

--- a/prisma/migrations/20260802200000_release_sync/migration.sql
+++ b/prisma/migrations/20260802200000_release_sync/migration.sql
@@ -1,0 +1,25 @@
+-- Release-to-campaign pipeline: deterministic post binding + sync bookkeeping.
+ALTER TABLE "Automation" ADD COLUMN "catnoTag" TEXT;
+
+CREATE TABLE "ReleaseSyncEvent" (
+    "id" TEXT NOT NULL,
+    "sku" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "outcome" TEXT NOT NULL,
+    "detail" TEXT,
+    "automationId" TEXT,
+    "processedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ReleaseSyncEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ReleaseSyncEvent_sku_eventType_key" ON "ReleaseSyncEvent"("sku", "eventType");
+
+CREATE TABLE "ReleaseProductState" (
+    "sku" TEXT NOT NULL,
+    "lastStatus" TEXT NOT NULL,
+    "seenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReleaseProductState_pkey" PRIMARY KEY ("sku")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -175,6 +175,10 @@ model Automation {
   postId         String?
   postUrl        String?
   pendingNextReel Boolean @default(false)
+  /// Catalogue number for deterministic post binding: when set, the attach
+  /// cron binds this campaign to the first media whose caption contains
+  /// #<catnoTag> (any media type), falling back to next-reel behavior.
+  catnoTag       String?
   matchAnyPost   Boolean @default(false)
   keywords       String[]
   matchAnyWord   Boolean @default(false)
@@ -378,4 +382,29 @@ enum OperationalEventLevel {
   INFO
   WARNING
   ERROR
+}
+
+/// One row per (sku, eventType) the release sync has already turned into a
+/// campaign (or deliberately skipped). Idempotence is structural: replays of
+/// the same shop snapshot can never create duplicates.
+model ReleaseSyncEvent {
+  id          String   @id @default(cuid())
+  sku         String
+  eventType   String
+  outcome     String
+  detail      String?
+  automationId String?
+  processedAt DateTime @default(now())
+
+  @@unique([sku, eventType])
+}
+
+/// Last stock status seen per exclusive SKU, so status flips (preorder ->
+/// in stock, out of stock -> in stock) can be derived from stateless shop
+/// snapshots.
+model ReleaseProductState {
+  sku        String   @id
+  lastStatus String
+  seenAt     DateTime @default(now())
+  updatedAt  DateTime @updatedAt
 }


### PR DESCRIPTION
Two read-only internal endpoints (Bearer CRON_SECRET) consumed by the label-platform marketing calendar on the same host:

- `POST /api/internal/lint-copy` — YOYAKU voice linter as a service (invented-noun rule dropped when no fact block is supplied)
- `GET /api/internal/campaign-stats?sku=` — automation matched by catnoTag + SENT DM count + link clicks

7 new tests, 164/164 suite green, typecheck + eslint clean.