### PR TITLE
Fix keyword matching for non-Latin scripts (Cyrillic, CJK, etc.)

### DIFF
--- a/__tests__/keyword-matcher.test.ts
+++ b/__tests__/keyword-matcher.test.ts
@@ -34,6 +34,19 @@ describe("stripSpecialCharacters", () => {
   it("should preserve numbers", () => {
     expect(stripSpecialCharacters("price123")).toBe("price123");
   });
+
+  it("should preserve non-Latin letters (Cyrillic)", () => {
+    expect(stripSpecialCharacters("Клод")).toBe("Клод");
+  });
+
+  it("should preserve non-Latin letters within punctuation", () => {
+    expect(stripSpecialCharacters("Клод!!")).toBe("Клод");
+  });
+
+  it("should preserve other scripts (Greek, CJK)", () => {
+    expect(stripSpecialCharacters("λόγος")).toBe("λόγος");
+    expect(stripSpecialCharacters("链接")).toBe("链接");
+  });
 });
 
 describe("matchKeywords — whole word matching", () => {
@@ -80,6 +93,39 @@ describe("matchKeywords — whole word matching", () => {
     const result = matchKeywords("hello world", ["link", "price"], true);
     expect(result.matched).toBe(false);
     expect(result.matchedKeyword).toBeNull();
+  });
+});
+
+describe("matchKeywords — non-Latin scripts", () => {
+  it("should match a Cyrillic keyword in whole-word mode", () => {
+    const result = matchKeywords("Клод", ["Клод"], true);
+    expect(result.matched).toBe(true);
+    expect(result.matchedKeyword).toBe("Клод");
+  });
+
+  it("should match a Cyrillic keyword inside a sentence", () => {
+    expect(matchKeywords("хочу Клод плиз", ["Клод"], true).matched).toBe(true);
+  });
+
+  it("should match a Cyrillic keyword surrounded by punctuation/emoji", () => {
+    expect(matchKeywords("🔥 Клод! 🔥", ["Клод"], true).matched).toBe(true);
+  });
+
+  it("should be case-insensitive for Cyrillic", () => {
+    expect(matchKeywords("клод", ["КЛОД"], true).matched).toBe(true);
+  });
+
+  it("should NOT match a different Cyrillic word in whole-word mode", () => {
+    // "Клодом" is a different word; whole-word must not fire on the stem.
+    expect(matchKeywords("Клодом", ["Клод"], true).matched).toBe(false);
+  });
+
+  it("should match a Cyrillic stem in partial mode", () => {
+    expect(matchKeywords("Клодом", ["Клод"], false).matched).toBe(true);
+  });
+
+  it("should match other scripts (CJK)", () => {
+    expect(matchKeywords("发我链接", ["链接"], false).matched).toBe(true);
   });
 });
 

--- a/lib/utils/keyword-matcher.ts
+++ b/lib/utils/keyword-matcher.ts
@@ -6,6 +6,13 @@
  * - Whole-word or partial matching
  * - Multi-keyword OR logic (any match = true)
  * - Emoji and special character stripping
+ *
+ * Unicode note: the original implementation used ASCII `\w` and `\b`, which
+ * treat every Cyrillic / CJK / accented letter as a "special character" and a
+ * non-word char. That silently deleted all non-Latin comment text before
+ * matching, so a Russian keyword like "Клод" could never match. Everything
+ * here uses Unicode property escapes (`\p{L}` letters, `\p{N}` numbers) with the
+ * `u` flag so non-Latin scripts work.
  */
 
 export interface KeywordMatchResult {
@@ -15,16 +22,16 @@ export interface KeywordMatchResult {
 
 /**
  * Strip emojis and special characters from text, keeping only
- * alphanumeric characters and whitespace.
+ * letters (any script), numbers, and whitespace.
  */
 export function stripSpecialCharacters(text: string): string {
-  // Remove emoji ranges and other special unicode chars
   return text
     .replace(
       /[\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F1E0}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}\u{FE00}-\u{FE0F}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1FA70}-\u{1FAFF}\u{200D}\u{20E3}]/gu,
       ""
     )
-    .replace(/[^\w\s]/g, " ")
+    // Keep letters (any script) and numbers; turn everything else into a space.
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -59,17 +66,21 @@ export function matchKeywords(
     if (!cleanedKeyword) continue;
 
     if (wholeWordMatch) {
-      // Build a regex for whole-word matching
       const escapedKeyword = cleanedKeyword.replace(
         /[.*+?^${}()|[\]\\]/g,
         "\\$&"
       );
-      const regex = new RegExp(`\\b${escapedKeyword}\\b`, "i");
+      // Unicode-aware "whole word": the keyword must not be flanked by another
+      // letter or number. Lookarounds replace ASCII `\b`, which never fires
+      // between two non-Latin characters.
+      const regex = new RegExp(
+        `(?<![\\p{L}\\p{N}])${escapedKeyword}(?![\\p{L}\\p{N}])`,
+        "iu"
+      );
       if (regex.test(cleanedText)) {
         return { matched: true, matchedKeyword: keyword };
       }
     } else {
-      // Partial match — keyword substring exists anywhere in the cleaned text
       if (cleanedText.includes(cleanedKeyword)) {
         return { matched: true, matchedKeyword: keyword };
       }


### PR DESCRIPTION
## Problem

Keyword matching silently fails for any non-Latin comment text. A campaign with the keyword `Клод` (or any Cyrillic, Greek, CJK, Arabic, etc. word) never fires, even on an exact comment.

Two ASCII assumptions in `lib/utils/keyword-matcher.ts` cause it:

1. `stripSpecialCharacters` uses `[^\w\s]`. The ASCII `\w` is `[A-Za-z0-9_]`, so every non-Latin letter counts as a "special character" and is replaced with a space. `stripSpecialCharacters("Клод")` returns `""`, so the text is empty before matching even begins.
2. Whole-word mode builds `\b<keyword>\b`. The ASCII `\b` never fires between two non-Latin characters, so `\bКлод\b` fails to match `Клод`.

Reproduce on `main`:

```js
stripSpecialCharacters("Клод")            // "" (expected "Клод")
matchKeywords("Клод", ["Клод"], true)     // { matched: false }  (expected true)
```

I hit this running OpenReply for a Russian-language account. It is not account specific. Every non-English creator is affected.

## Fix

Use Unicode property escapes with the `u` flag:

- Strip with `[^\p{L}\p{N}\s]` so letters of any script and numbers survive.
- Replace `\b` with lookarounds `(?<![\p{L}\p{N}])` and `(?![\p{L}\p{N}])` for whole-word boundaries.

ASCII behavior is unchanged, so existing English campaigns keep working exactly as before.

## Tests

Added cases to `__tests__/keyword-matcher.test.ts` for Cyrillic, Greek, and CJK across whole-word and partial modes, including the stem case (`Клодом` must not whole-word match `Клод`, but must partial match).

- On `main`: 9 of the new tests fail, all existing tests pass.
- With this fix: all 33 pass.

```
Test Files  1 passed (1)
     Tests  33 passed (33)
```