### PR TITLE
Document that publishing does not grant Advanced Access, and name the failing Graph call in errors

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -195,6 +195,24 @@ https://your-app.vercel.app/terms
 
 Then publish. Depending on your access level, Meta may let you go live for your own tester accounts immediately, or it may require App Review first (see the last section).
 
+### Publishing is not Advanced Access: every account still needs a role on the app
+
+This one costs an afternoon because the symptom points nowhere near the cause.
+
+A published app still holds **Standard Access** to `instagram_business_basic`, `instagram_business_manage_comments`, and `instagram_business_manage_messages`. Standard Access only covers Instagram accounts that have a role on your app — admins, developers, and Instagram testers. Publishing makes the app live; it does not widen who the permissions apply to. Advanced Access, which covers everyone else, comes only from App Review.
+
+So connecting a second account fails even though the first one works, on the same app, with the same code.
+
+The symptom: Instagram's consent screen appears and the login succeeds, the code exchange at `api.instagram.com/oauth/access_token` returns a normal `IGAA…` token with all the requested permissions — and then every single call against `graph.instagram.com` is refused:
+
+```
+Unsupported request - method type: get  [code=100, type=IGApiException]
+```
+
+`/access_token`, `/refresh_access_token`, `/me` — all of them, identically. Nothing about the message suggests a missing role, and the token itself looks fine.
+
+The fix for your own accounts is the same two-part dance as Step 6, once per account: invite the Instagram username under App roles, Roles, Instagram testers, then accept the invite inside Instagram under Edit profile, Apps and websites, Tester invites. For accounts you do not control, you need App Review — see [META_APP_REVIEW.md](../META_APP_REVIEW.md).
+
 ### The account ID trap (informational)
 
 You do not have to do anything here; OpenReply handles it. It is worth understanding because it is invisible when it goes wrong.

--- a/lib/meta/client.ts
+++ b/lib/meta/client.ts
@@ -116,7 +116,14 @@ async function handleResponse<T>(response: Response): Promise<T> {
     const code = err?.code ?? response.status;
     const subcode = err?.error_subcode;
     const traceId = err?.fbtrace_id;
-    const message = err?.message ?? "Unknown Meta API error";
+    // Without the path a Meta error is unattributable: a connect runs several
+    // calls in a row that fail with the identical message. The query string is
+    // dropped on purpose — it carries the access token.
+    let path = "";
+    try {
+      path = ` (${new URL(response.url).pathname})`;
+    } catch {}
+    const message = `${err?.message ?? "Unknown Meta API error"}${path} [code=${code} sub=${subcode ?? "-"} type=${err?.type ?? "-"} trace=${traceId ?? "-"}]`;
 
     switch (code) {
       case 190:


### PR DESCRIPTION
Two small things that came out of self-hosting this for several Instagram accounts.

## The docs part

Connecting a second Instagram account failed while the first one worked — same app, same code, app already published.

The cause is that a published app still holds **Standard Access**, which only covers accounts that have a role on the app. `META_APP_REVIEW.md` mentions this in terms of App Review, but nothing connects it to the symptom you actually hit, and the symptom points nowhere near the cause:

- Instagram's consent screen appears and the login succeeds
- the code exchange at `api.instagram.com/oauth/access_token` returns a normal `IGAA…` token with all requested permissions
- every subsequent call against `graph.instagram.com` is refused with `Unsupported request - method type: get [code=100, type=IGApiException]` — `/access_token`, `/refresh_access_token` and `/me` alike

Adding the account as an Instagram tester (and accepting the invite inside Instagram) fixes it immediately. The new section sits right after the publish step, where you run into it.

## The error message part

Finding that took several rounds, because a failed connect makes three Graph calls in a row that fail with the *identical* message — the message alone never said which call broke.

`handleResponse` now appends the request path plus Meta's `code`, `error_subcode`, `type` and `fbtrace_id`:

```
Unsupported request - method type: get (/v25.0/me) [code=100 sub=- type=IGApiException trace=AEvqSnG…]
```

The query string is dropped on purpose — it carries the access token.

## Notes for review

- No behaviour change: same error classes are thrown for the same codes, only the message text is richer.
- `response.url` is wrapped in try/catch so a malformed URL can never turn an API error into a `TypeError`.
- Typecheck clean, 132 tests pass.
