### PR TITLE
Allow magic links over your own SMTP server via EMAIL_SERVER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ REDIS_URL=redis://localhost:6379
 RESEND_API_KEY=re_...
 EMAIL_FROM=OpenReply <login@example.com>
 
+# Optional: use your own SMTP server instead of Resend. When EMAIL_SERVER is
+# set it takes over and RESEND_API_KEY is not needed. URL-encode special
+# characters in user and password (@ becomes %40).
+# EMAIL_SERVER=smtps://login%40example.com:password@mail.example.com:465
+
 # Meta / Instagram
 META_GRAPH_API_VERSION=v25.0
 INSTAGRAM_APP_ID=your-instagram-app-id

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,4 @@
-import { signIn } from "@/lib/auth";
+import { EMAIL_PROVIDER_ID, signIn } from "@/lib/auth";
 import { getCampaignTemplate } from "@/lib/templates/campaign-templates";
 
 export const metadata = {
@@ -25,7 +25,7 @@ export default async function LoginPage({
 
   async function sendMagicLink(formData: FormData) {
     "use server";
-    await signIn("resend", {
+    await signIn(EMAIL_PROVIDER_ID, {
       email: String(formData.get("email") ?? ""),
       redirectTo: callbackUrl,
     });

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -19,7 +19,7 @@ The web app and the worker must share the same `DATABASE_URL`, the same `REDIS_U
 
 - A Facebook account. Meta developer registration is built on it. There is no Instagram-only path.
 - An Instagram Business or Creator account. A personal account cannot be connected. Switch it in the Instagram app under Settings, Account type, if needed.
-- A [Resend](https://resend.com) account for login emails, with a verified sender domain. Login is email magic links only, so without this nobody can sign in.
+- A [Resend](https://resend.com) account for login emails, with a verified sender domain. Login is email magic links only, so without this nobody can sign in. If you already run your own mail server, you can point `EMAIL_SERVER` at it instead and skip Resend entirely — see the [environment variables](#environment-variables) table.
 - Somewhere to host. The recommended setup, used throughout this guide, is Vercel for the web app and Railway for the worker plus Postgres and Redis. Both have free tiers that are enough to run this for a single account.
 
 ## Hosting and your domain
@@ -94,6 +94,7 @@ Copy `.env.example` to `.env` for local work, or set these in Vercel and Railway
 | `REDIS_URL` | Redis connection string. Must support blocking commands, so an HTTP-only Redis will not work with BullMQ. |
 | `RESEND_API_KEY` | Resend key. Login is email magic links only, so without this nobody can sign in. |
 | `EMAIL_FROM` | A sender on a domain you verified in Resend. The placeholder will not deliver. |
+| `EMAIL_SERVER` | Optional. An SMTP URL, for example `smtps://login%40example.com:password@mail.example.com:465`. Set it to send magic links through your own mail server instead of Resend; then `RESEND_API_KEY` is not needed. URL-encode special characters in the user and password (`@` becomes `%40`). Port 465 with `smtps://` is implicit TLS, port 587 with `smtp://` is STARTTLS. |
 | `META_GRAPH_API_VERSION` | Graph API version, for example `v25.0`. |
 | `INSTAGRAM_APP_ID` | From the Meta app, see Step 6. |
 | `INSTAGRAM_APP_SECRET` | From the Meta app. |

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,4 +1,5 @@
 import NextAuth, { type NextAuthConfig } from "next-auth";
+import Nodemailer from "next-auth/providers/nodemailer";
 import Resend from "next-auth/providers/resend";
 import { PrismaAdapter } from "@auth/prisma-adapter";
 import { prisma } from "@/lib/db/client";
@@ -6,13 +7,27 @@ import { ensureWorkspaceForUser, getPrimaryWorkspace } from "@/lib/workspace";
 
 type AdapterPrismaClient = Parameters<typeof PrismaAdapter>[0];
 
+const emailFrom = process.env.EMAIL_FROM ?? "OpenReply <login@example.com>";
+// Setting EMAIL_SERVER switches magic links to your own SMTP server, for
+// self-hosters who do not want a third-party mail service. Resend stays the
+// default, so an existing deployment is unaffected.
+const smtpServer = process.env.EMAIL_SERVER;
+
+/**
+ * Provider id the login form has to sign in with. It differs per transport,
+ * so it is derived here rather than hardcoded at the call site.
+ */
+export const EMAIL_PROVIDER_ID = smtpServer ? "nodemailer" : "resend";
+
 export const authConfig = {
   adapter: PrismaAdapter(prisma as unknown as AdapterPrismaClient),
   providers: [
-    Resend({
-      apiKey: process.env.RESEND_API_KEY ?? "missing-resend-api-key",
-      from: process.env.EMAIL_FROM ?? "OpenReply <login@example.com>",
-    }),
+    smtpServer
+      ? Nodemailer({ server: smtpServer, from: emailFrom })
+      : Resend({
+          apiKey: process.env.RESEND_API_KEY ?? "missing-resend-api-key",
+          from: emailFrom,
+        }),
   ],
   callbacks: {
     async session({ session, user }) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ioredis": "^5.10.1",
         "next": "^16.2.6",
         "next-auth": "^5.0.0-beta.31",
+        "nodemailer": "^7.0.13",
         "pg": "^8.20.0",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -25,6 +26,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/nodemailer": "^8.0.1",
         "@types/pg": "^8.20.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3010,6 +3012,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.1.tgz",
+      "integrity": "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -7525,6 +7537,15 @@
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/oauth4webapi": {
       "version": "3.8.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "ioredis": "^5.10.1",
     "next": "^16.2.6",
     "next-auth": "^5.0.0-beta.31",
+    "nodemailer": "^7.0.13",
     "pg": "^8.20.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
@@ -32,6 +33,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/nodemailer": "^8.0.1",
     "@types/pg": "^8.20.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
Login is email magic links only, so a Resend account is currently a hard requirement to run OpenReply at all — including for people who already operate their own mail server and would rather not add a third-party service (and a domain verification round) for three emails a month.

This makes the transport configurable. Setting `EMAIL_SERVER` to an SMTP URL switches Auth.js to its Nodemailer provider; leaving it unset keeps Resend exactly as before.

```
EMAIL_SERVER=smtps://login%40example.com:password@mail.example.com:465
```

## What changed

- `lib/auth.ts` picks the provider based on `EMAIL_SERVER` and exports `EMAIL_PROVIDER_ID`, because the id differs per transport (`nodemailer` vs `resend`) and `signIn()` needs the matching one.
- `app/login/page.tsx` signs in with `EMAIL_PROVIDER_ID` instead of the hardcoded `"resend"`.
- `docs/setup.md`: a row in the environment table and a pointer in the prerequisites.
- `.env.example`: commented-out example.
- Adds `nodemailer` as a dependency — `next-auth/providers/nodemailer` requires it. It is only loaded when the provider is used.

## Notes for review

- Default behaviour is unchanged: no `EMAIL_SERVER`, no difference.
- The hardcoded provider id was the one real trap here. Swapping the provider without updating the `signIn()` call fails as `MissingCSRF`, which reads like a cookie or host problem and sends you looking in the wrong place. Deriving the id from one spot removes that.
- URL-encoding matters for SMTP credentials (`@` becomes `%40`); documented in both the env table and `.env.example`.
- Typecheck clean, 132 tests pass.
