### PR TITLE
fix(post-picker): keep large libraries usable on mobile

### DIFF
--- a/components/post-picker.tsx
+++ b/components/post-picker.tsx
@@ -12,6 +12,8 @@
 import { useEffect, useState } from "react";
 import { readCache, writeCache } from "@/lib/client-cache";
 
+const PAGE_SIZE = 60;
+
 interface InstagramPost {
   id: string;
   caption?: string;
@@ -47,6 +49,10 @@ export default function PostPicker({
   const [query, setQuery] = useState("");
   // The post currently hovered — its video (if it's a reel) plays a preview.
   const [hoveredId, setHoveredId] = useState<string | null>(null);
+  // The grid loads the whole library (all=true). On accounts with hundreds of
+  // posts, rendering every tile at once is enough to make mobile Safari drop
+  // the page, so they are revealed in batches.
+  const [shown, setShown] = useState(PAGE_SIZE);
 
   useEffect(() => {
     let cancelled = false;
@@ -119,11 +125,14 @@ export default function PostPicker({
     );
   }
 
-  const visible = query.trim()
+  const matching = query.trim()
     ? posts.filter((p) =>
         (p.caption ?? "").toLowerCase().includes(query.trim().toLowerCase())
       )
     : posts;
+
+  const visible = matching.slice(0, shown);
+  const remaining = matching.length - visible.length;
 
   return (
     <div className="space-y-2">
@@ -148,7 +157,10 @@ export default function PostPicker({
               Already used
             </p>
           )}
-          <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 max-h-64 overflow-y-auto p-1">
+          {/* auto-rows-min + content-start keep each row at its natural height.
+              Without them the rows share out max-h-64 instead of scrolling, and
+              the square thumbnails flatten into strips. */}
+          <div className="grid grid-cols-3 sm:grid-cols-4 gap-2 max-h-64 auto-rows-min content-start overflow-y-auto p-1">
             {visible.map((post) => {
               const isSelected = selectedPostId === post.id;
               const usedByName = usedPostIds?.[post.id];
@@ -183,6 +195,8 @@ export default function PostPicker({
               <img
                 src={thumb}
                 alt={post.caption?.slice(0, 50) ?? "Instagram post"}
+                loading="lazy"
+                decoding="async"
                 className={`w-full h-full object-cover ${isUsed ? "opacity-75" : ""}`}
               />
             ) : (
@@ -213,6 +227,15 @@ export default function PostPicker({
               );
             })}
           </div>
+          {remaining > 0 && (
+            <button
+              type="button"
+              onClick={() => setShown((n) => n + PAGE_SIZE)}
+              className="w-full rounded-lg border border-border py-2 text-sm text-muted hover:text-foreground"
+            >
+              Show {Math.min(PAGE_SIZE, remaining)} more
+            </button>
+          )}
         </>
       )}
     </div>


### PR DESCRIPTION
## What

The post picker asks for the whole library (`all=true`) and renders every tile in one pass. On an account with a few hundred posts that is enough for mobile Safari to run out of memory: the page reloads itself until iOS gives up with *"A problem repeatedly occurred"*, so the campaign builder cannot be opened from a phone at all. Desktop survives it, which is probably why it has gone unnoticed.

The same screen has a second, smaller problem: the thumbnails flatten into thin strips. The grid rows share out the `max-h-64` box instead of scrolling, so `aspect-square` loses.

## Changes

- `loading="lazy"` and `decoding="async"` on the thumbnails, so only what is on screen gets fetched and decoded
- reveal posts in batches of 60 with a *Show more* button — caption search still runs over the entire library, so older reels stay reachable
- `auto-rows-min` + `content-start` on the grid, so rows keep their natural height and the box scrolls

No API or data changes; the picker still loads the full library.

## Testing

Reproduced on a self-hosted instance with ~300 posts: before the change the builder never opened on an iPhone, after it the grid loads and scrolls normally. Desktop also opens noticeably faster, since it no longer waits on every thumbnail.

`npm run typecheck`, `npm run lint`, `npm test` (132 passing) and `npm run build` all pass locally.