### PR TITLE
Send a bilingual campaign in the language of the matched keyword

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ INSTAGRAM_APP_ID=your-instagram-app-id
 INSTAGRAM_APP_SECRET=your-instagram-app-secret
 FACEBOOK_APP_SECRET=your-facebook-app-secret
 WEBHOOK_VERIFY_TOKEN=replace-with-a-webhook-verify-token
+
+# Optional: send a bilingual campaign in one language only, chosen by the
+# keyword that matched the comment. Write the message once with each half
+# opened by its flag (🇮🇹 … 🇺🇸 …) and map keywords to languages here — an
+# unmapped keyword leaves the message whole. Supported: it, en, es, fr, de, pt.
+# KEYWORD_LANGUAGES=sfondi:it,wallpaper:en,wallpapers:en

--- a/__tests__/language.test.ts
+++ b/__tests__/language.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { pickLabel, pickLanguage } from "../lib/utils/language";
+
+const IT = "🇮🇹";
+const EN = "🇺🇸";
+
+const BILINGUAL = `${IT} Ciao, vuoi scaricare gli sfondi?\n\n${EN} Hi! Are you interested in the wallpapers?`;
+
+/**
+ * KEYWORD_LANGUAGES is read once at import time, so the keyword tests reload
+ * the module with the environment already in place.
+ */
+async function loadWithEnv(value: string | undefined) {
+  vi.resetModules();
+  if (value === undefined) delete process.env.KEYWORD_LANGUAGES;
+  else process.env.KEYWORD_LANGUAGES = value;
+  return import("../lib/utils/language");
+}
+
+afterEach(() => {
+  delete process.env.KEYWORD_LANGUAGES;
+  vi.resetModules();
+});
+
+describe("languageForKeyword", () => {
+  it("maps a configured keyword, case- and space-insensitively", async () => {
+    const { languageForKeyword } = await loadWithEnv(
+      "sfondi:it, wallpapers:en"
+    );
+    expect(languageForKeyword("sfondi")).toBe("it");
+    expect(languageForKeyword("  WALLPAPERS ")).toBe("en");
+  });
+
+  it("returns null for an unmapped keyword or no configuration", async () => {
+    const configured = await loadWithEnv("sfondi:it");
+    expect(configured.languageForKeyword("hello")).toBeNull();
+    expect(configured.languageForKeyword(null)).toBeNull();
+
+    const unset = await loadWithEnv(undefined);
+    expect(unset.languageForKeyword("sfondi")).toBeNull();
+  });
+
+  it("skips malformed pairs instead of throwing", async () => {
+    const { languageForKeyword } = await loadWithEnv(
+      "sfondi:it,broken,ciao:klingon,:en"
+    );
+    expect(languageForKeyword("sfondi")).toBe("it");
+    expect(languageForKeyword("ciao")).toBeNull();
+  });
+});
+
+describe("pickLanguage", () => {
+  it("keeps only the requested half and drops the flag", () => {
+    expect(pickLanguage(BILINGUAL, "it")).toBe(
+      "Ciao, vuoi scaricare gli sfondi?"
+    );
+    expect(pickLanguage(BILINGUAL, "en")).toBe(
+      "Hi! Are you interested in the wallpapers?"
+    );
+  });
+
+  it("keeps the whole message when no language was matched", () => {
+    expect(pickLanguage(BILINGUAL, null)).toBe(BILINGUAL);
+  });
+
+  it("keeps the whole message when it is not bilingual", () => {
+    const single = `${IT} Solo italiano`;
+    expect(pickLanguage(single, "it")).toBe(single);
+    expect(pickLanguage("No flags at all", "it")).toBe("No flags at all");
+  });
+
+  it("keeps the whole message when the requested language is absent", () => {
+    expect(pickLanguage(BILINGUAL, "es")).toBe(BILINGUAL);
+  });
+
+  it("re-attaches a trailing {link} to the half that lost it", () => {
+    const withLink = `${IT} Ecco gli sfondi\n\n${EN} Here are the wallpapers\n\n{link}`;
+    expect(pickLanguage(withLink, "it")).toBe("Ecco gli sfondi\n\n{link}");
+    expect(pickLanguage(withLink, "en")).toBe(
+      "Here are the wallpapers\n\n{link}"
+    );
+  });
+
+  it("splits a third language on its own flag", () => {
+    const three = `${IT} Italiano\n\n${EN} English\n\n🇪🇸 Español`;
+    expect(pickLanguage(three, "en")).toBe("English");
+    expect(pickLanguage(three, "es")).toBe("Español");
+  });
+});
+
+describe("pickLabel", () => {
+  it("falls back to the first half so Instagram does not truncate it", () => {
+    expect(pickLabel(`${IT} Sì grazie\n${EN} Yes please`, null)).toBe(
+      "Sì grazie"
+    );
+  });
+
+  it("still honours a known language", () => {
+    expect(pickLabel(`${IT} Sì grazie\n${EN} Yes please`, "en")).toBe(
+      "Yes please"
+    );
+  });
+
+  it("passes through a single-language label untouched", () => {
+    expect(pickLabel("Download Link", "it")).toBe("Download Link");
+    expect(pickLabel(null, "it")).toBe("");
+  });
+});

--- a/lib/queue/dm-worker.ts
+++ b/lib/queue/dm-worker.ts
@@ -27,6 +27,12 @@ import {
 } from "@/lib/meta/client";
 import { decryptToken } from "@/lib/meta/oauth";
 import { matchKeywords } from "@/lib/utils/keyword-matcher";
+import {
+  isLang,
+  languageForKeyword,
+  pickLabel,
+  type Lang,
+} from "@/lib/utils/language";
 import { reserveDMSlot } from "@/lib/utils/rate-limiter";
 import {
   releaseWorkspaceDMReservation,
@@ -100,13 +106,27 @@ function buildInlineLinkFallback(
   message: string,
   commenterName: string | null | undefined,
   trackedLinks: WorkerTrackedLink[],
-  bodyText: string
+  bodyText: string,
+  language?: Lang | null
 ): string {
   const base =
-    renderMessageWithTracking({ message, commenterName, trackedLinks }) ||
-    bodyText;
+    renderMessageWithTracking({
+      message,
+      commenterName,
+      trackedLinks,
+      language,
+    }) || bodyText;
   const extraUrls = trackedLinks.slice(1).map((link) => buildTrackedUrl(link.slug));
   return extraUrls.length > 0 ? `${base}\n${extraUrls.join("\n")}` : base;
+}
+
+/**
+ * Appends the language to a button payload (`reveal:<id>` -> `reveal:<id>:it`).
+ * With no language the payload is byte-identical to the old one, so buttons
+ * sent before this feature keep working.
+ */
+function withLanguage(payload: string, language: Lang | null | undefined) {
+  return language ? `${payload}:${language}` : payload;
 }
 
 type RevealAutomation = {
@@ -126,7 +146,8 @@ async function sendRevealDirectMessage(
   automation: RevealAutomation,
   userId: string,
   commenterName: string | null,
-  context: string
+  context: string,
+  language?: Lang | null
 ): Promise<void> {
   if (automation.trackedLinks.length === 0) {
     await sendDirectMessage(
@@ -137,6 +158,7 @@ async function sendRevealDirectMessage(
         message: automation.dmMessage,
         commenterName,
         trackedLinks: automation.trackedLinks,
+        language,
       })
     );
     return;
@@ -147,6 +169,7 @@ async function sendRevealDirectMessage(
     renderMessageWithoutLink({
       message: automation.dmMessage,
       commenterName,
+      language,
     }) || "Here's your link:";
   const buttons = buildLinkButtons(
     automation.trackedLinks,
@@ -179,7 +202,8 @@ async function sendRevealDirectMessage(
           automation.dmMessage,
           commenterName,
           automation.trackedLinks,
-          bodyText
+          bodyText,
+          language
         )
       );
     } catch {
@@ -236,6 +260,11 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
     if (!matchResult.matched) {
       continue;
     }
+
+    // The matched keyword decides the language (see KEYWORD_LANGUAGES). An
+    // unmapped keyword — or an "any word" campaign — leaves it null and the
+    // message goes out in full, bilingual, as before.
+    const language = languageForKeyword(matchResult.matchedKeyword);
 
     const existingLog = await prisma.dmLog.findUnique({
       where: {
@@ -369,6 +398,7 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
           message: chosen,
           commenterName,
           trackedLinks: automation.trackedLinks,
+          language,
         });
         await sendCommentReply(accessToken, commentId, publicReply);
         await prisma.dmLog.update({
@@ -546,16 +576,23 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
           message: automation.openingDmMessage as string,
           commenterName,
           trackedLinks: [],
+          language,
         });
         await sendPrivateReplyWithButton(
           accessToken,
           automation.instagramAccount.instagramId,
           commentId,
           openingText,
-          automation.openingDmButtonLabel as string,
-          automation.requireFollow
-            ? `followcheck:${automation.id}`
-            : `reveal:${automation.id}`
+          pickLabel(automation.openingDmButtonLabel, language),
+          // The language travels in the payload: by the time the user taps the
+          // button the original comment is out of the picture, and without it
+          // the final message would fall back to bilingual halfway through.
+          withLanguage(
+            automation.requireFollow
+              ? `followcheck:${automation.id}`
+              : `reveal:${automation.id}`,
+            language
+          )
         );
       } else if (sendFollowPrompt) {
         const promptText = renderMessageWithoutLink({
@@ -563,14 +600,16 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
             automation.followPromptMessage ||
             "quick favor before i send your link. i don't make any money from this, it's free. if you want to support me, just don't unfollow after, and star the repo on github if it helps you. tap the button once you're following and i'll send it over",
           commenterName,
+          language,
         });
         await sendPrivateReplyWithButton(
           accessToken,
           automation.instagramAccount.instagramId,
           commentId,
           promptText,
-          automation.followPromptButtonLabel || "i'm following",
-          `followcheck:${automation.id}`
+          pickLabel(automation.followPromptButtonLabel, language) ||
+            "i'm following",
+          withLanguage(`followcheck:${automation.id}`, language)
         );
       } else if (automation.trackedLinks.length > 0) {
         // Try button template first; if Meta rejects it, fall back to inline links.
@@ -578,6 +617,7 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
           renderMessageWithoutLink({
             message: automation.dmMessage,
             commenterName,
+            language,
           }) || "Here's your link:";
         const buttons = buildLinkButtons(
           automation.trackedLinks,
@@ -606,7 +646,8 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
             automation.dmMessage,
             commenterName,
             automation.trackedLinks,
-            bodyText
+            bodyText,
+            language
           );
           try {
             await sendPrivateReply(
@@ -627,6 +668,7 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
           message: automation.dmMessage,
           commenterName,
           trackedLinks: automation.trackedLinks,
+          language,
         });
         await sendPrivateReply(
           accessToken,
@@ -675,7 +717,8 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
 
 /**
  * Deliver the reveal message after a user taps an opening DM's button.
- * The postback payload is `reveal:<automationId>`; the sender is the user's
+ * The postback payload is `reveal:<automationId>` (or `reveal:<automationId>:<lang>`
+ * when the keyword picked a language); the sender is the user's
  * IGSID (same id as their comment author id), which we DM directly.
  */
 async function processPostback(job: Job<ProcessPostbackJob>): Promise<void> {
@@ -683,9 +726,13 @@ async function processPostback(job: Job<ProcessPostbackJob>): Promise<void> {
 
   const isFollowCheck = payload.startsWith("followcheck:");
   if (!isFollowCheck && !payload.startsWith("reveal:")) return;
-  const automationId = payload.slice(
+  const rest = payload.slice(
     isFollowCheck ? "followcheck:".length : "reveal:".length
   );
+  // The language suffix is optional: buttons sent before this feature arrive
+  // without one and stay valid (null language -> the full bilingual message).
+  const [automationId, langSuffix] = rest.split(":");
+  const language: Lang | null = isLang(langSuffix) ? langSuffix : null;
 
   const automation = await prisma.automation.findFirst({
     where: { id: automationId, isActive: true },
@@ -752,6 +799,7 @@ async function processPostback(job: Job<ProcessPostbackJob>): Promise<void> {
           automation.followPromptMessage ||
           "quick favor before i send your link. i don't make any money from this, it's free. if you want to support me, just don't unfollow after, and star the repo on github if it helps you. tap the button once you're following and i'll send it over",
         commenterName,
+        language,
       });
       try {
         await sendDirectMessageWithButton(
@@ -759,8 +807,9 @@ async function processPostback(job: Job<ProcessPostbackJob>): Promise<void> {
           automation.instagramAccount.instagramId,
           userId,
           promptText,
-          automation.followPromptButtonLabel || "i'm following",
-          `followcheck:${automation.id}`
+          pickLabel(automation.followPromptButtonLabel, language) ||
+            "i'm following",
+          withLanguage(`followcheck:${automation.id}`, language)
         );
       } catch (error) {
         console.log(
@@ -800,7 +849,8 @@ async function processPostback(job: Job<ProcessPostbackJob>): Promise<void> {
       automation,
       userId,
       commenterName,
-      "postback"
+      "postback",
+      language
     );
     // Optional appreciation follow-up: once the link has been delivered, send a
     // short thank-you. It is scheduled as its own delayed job so it can go out
@@ -968,6 +1018,9 @@ async function processMessage(job: Job<ProcessMessageJob>): Promise<void> {
 
     if (!matchResult.matched) continue;
 
+    // Same rule as the comment path: the matched keyword picks the language.
+    const language = languageForKeyword(matchResult.matchedKeyword);
+
     const existingLog = await prisma.dmLog.findUnique({
       where: {
         automationId_commentId: {
@@ -1091,14 +1144,16 @@ async function processMessage(job: Job<ProcessMessageJob>): Promise<void> {
             automation.followPromptMessage ||
             "Almost there! Follow me and tap the button below to grab your link 💛",
           commenterName,
+          language,
         });
         await sendDirectMessageWithButton(
           accessToken,
           automation.instagramAccount.instagramId,
           senderId,
           promptText,
-          automation.followPromptButtonLabel || "I'm following ✅",
-          `followcheck:${automation.id}`
+          pickLabel(automation.followPromptButtonLabel, language) ||
+            "I'm following ✅",
+          withLanguage(`followcheck:${automation.id}`, language)
         );
       } else {
         await sendRevealDirectMessage(
@@ -1106,7 +1161,8 @@ async function processMessage(job: Job<ProcessMessageJob>): Promise<void> {
           automation,
           senderId,
           commenterName,
-          "message trigger"
+          "message trigger",
+          language
         );
 
         // The link has been delivered, so the appreciation follow-up applies

--- a/lib/tracking/message.ts
+++ b/lib/tracking/message.ts
@@ -1,3 +1,5 @@
+import { pickLanguage, type Lang } from "@/lib/utils/language";
+
 export interface MessageTrackedLink {
   slug: string;
   destinationUrl: string;
@@ -41,11 +43,13 @@ export function replaceUrlWithTrackedPlaceholder(
 export function renderMessageWithoutLink({
   message,
   commenterName,
+  language,
 }: {
   message: string;
   commenterName?: string | null;
+  language?: Lang | null;
 }) {
-  return message
+  return pickLanguage(message, language)
     .replace(/\{username\}/gi, commenterName ?? "there")
     .replace(/\s*\{link\}\s*/gi, " ")
     .trim();
@@ -66,13 +70,18 @@ export function renderMessageWithTracking({
   commenterName,
   trackedLinks,
   baseUrl,
+  language,
 }: {
   message: string;
   commenterName?: string | null;
   trackedLinks?: MessageTrackedLink[];
   baseUrl?: string;
+  language?: Lang | null;
 }) {
-  let rendered = message.replace(/\{username\}/gi, commenterName ?? "there");
+  let rendered = pickLanguage(message, language).replace(
+    /\{username\}/gi,
+    commenterName ?? "there"
+  );
   const primaryLink = trackedLinks?.[0];
 
   if (!primaryLink) return rendered;

--- a/lib/utils/language.ts
+++ b/lib/utils/language.ts
@@ -1,0 +1,173 @@
+/**
+ * Picks the language of a reply from the keyword that matched the comment.
+ *
+ * Campaigns that serve a bilingual audience are written once, with each half
+ * marked by a flag emoji:
+ *
+ *   🇮🇹 Ciao, vuoi scaricare gli sfondi?
+ *
+ *   🇺🇸 Hi! Are you interested in downloading the wallpapers?
+ *
+ * Someone commenting an Italian keyword then gets only the Italian half, and
+ * an English keyword only the English one, instead of a message twice as long
+ * as it needs to be.
+ *
+ * Which keyword maps to which language is configuration, not code: set
+ * KEYWORD_LANGUAGES in the environment (see .env.example). When a keyword is
+ * unmapped — the variable is unset, the campaign matches any word, or the
+ * comment contains keywords of both languages — the language stays null and
+ * the whole message goes out, exactly as it did before this feature existed.
+ */
+
+export const SUPPORTED_LANGUAGES = [
+  "it",
+  "en",
+  "es",
+  "fr",
+  "de",
+  "pt",
+] as const;
+
+export type Lang = (typeof SUPPORTED_LANGUAGES)[number];
+
+/**
+ * The flag that opens each half of a bilingual message. A language can only be
+ * split out if its flag is listed here.
+ */
+const LANGUAGE_FLAGS: Record<Lang, string> = {
+  it: "🇮🇹",
+  en: "🇺🇸",
+  es: "🇪🇸",
+  fr: "🇫🇷",
+  de: "🇩🇪",
+  pt: "🇵🇹",
+};
+
+/**
+ * Tokens that belong to no language in particular. They are usually written
+ * once at the very end of the message, after the last half, so a naive cut
+ * would drop the link for everyone but the reader of the final language.
+ */
+const NEUTRAL_TOKENS = [/\{link\}/i];
+
+export function isLang(value: unknown): value is Lang {
+  return (
+    typeof value === "string" &&
+    (SUPPORTED_LANGUAGES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Parses KEYWORD_LANGUAGES: a comma-separated list of `keyword:lang` pairs,
+ * e.g. "sfondi:it, wallpaper:en, wallpapers:en". Keywords are compared
+ * lowercased and trimmed; unknown languages and malformed pairs are skipped
+ * rather than throwing, so a typo in the environment degrades to bilingual
+ * messages instead of breaking the worker.
+ */
+function parseKeywordLanguages(raw: string | undefined): Map<string, Lang> {
+  const map = new Map<string, Lang>();
+  if (!raw) return map;
+
+  for (const pair of raw.split(",")) {
+    const separator = pair.lastIndexOf(":");
+    if (separator === -1) continue;
+
+    const keyword = pair.slice(0, separator).trim().toLowerCase();
+    const lang = pair.slice(separator + 1).trim().toLowerCase();
+    if (keyword && isLang(lang)) map.set(keyword, lang);
+  }
+
+  return map;
+}
+
+// Read once: the worker is long-lived and the variable cannot change without
+// a restart.
+const KEYWORD_LANGUAGE = parseKeywordLanguages(process.env.KEYWORD_LANGUAGES);
+
+export function languageForKeyword(
+  keyword: string | null | undefined
+): Lang | null {
+  if (!keyword) return null;
+  return KEYWORD_LANGUAGE.get(keyword.trim().toLowerCase()) ?? null;
+}
+
+/**
+ * Re-attaches the neutral tokens that the chosen half does not contain, so a
+ * {link} written at the bottom of the message survives the cut.
+ */
+function preserveTokens(section: string, full: string): string {
+  let out = section;
+
+  for (const token of NEUTRAL_TOKENS) {
+    if (token.test(full) && !token.test(out)) {
+      const match = token.exec(full);
+      if (match) out = `${out.trim()}\n\n${match[0]}`;
+    }
+  }
+
+  return out;
+}
+
+/** Every flag present in the message, in the order they appear. */
+function findFlags(message: string): { lang: Lang; at: number }[] {
+  return SUPPORTED_LANGUAGES.map((lang) => ({
+    lang,
+    at: message.indexOf(LANGUAGE_FLAGS[lang]),
+  }))
+    .filter((flag) => flag.at !== -1)
+    .sort((a, b) => a.at - b.at);
+}
+
+/**
+ * Extracts the half of the message written in the requested language.
+ *
+ * Returns the message untouched when the language is unknown or the message is
+ * not written in the bilingual format, so single-language campaigns keep
+ * working without any change.
+ *
+ * `fallback` decides what happens with no language to go on: "full" keeps the
+ * whole text and loses nothing, "first" keeps the half that comes first — see
+ * pickLabel() for why button labels need the latter.
+ */
+export function pickLanguage(
+  message: string,
+  lang: Lang | null | undefined,
+  fallback: "full" | "first" = "full"
+): string {
+  if (!message) return message;
+  if (!lang && fallback === "full") return message;
+
+  const flags = findFlags(message);
+  // At least two flags are needed to cut: with a single one there is no way to
+  // tell where one language ends and the next begins.
+  if (flags.length < 2) return message;
+
+  const index = lang ? flags.findIndex((flag) => flag.lang === lang) : 0;
+  // The message is bilingual, but not in the language the keyword asked for:
+  // sending the whole thing beats sending the wrong half.
+  if (index === -1) return message;
+
+  const start = flags[index].at + LANGUAGE_FLAGS[flags[index].lang].length;
+  // A half runs up to the next flag, or to the end for the last one.
+  const end = index + 1 < flags.length ? flags[index + 1].at : message.length;
+
+  // The flag itself is dropped: with a single language left there is nothing
+  // to signal, and the message reads less like a template.
+  const section = message.slice(start, end).trim();
+  if (!section) return message;
+
+  return preserveTokens(section, message);
+}
+
+/**
+ * Variant for button labels: always narrows down to one language, even when
+ * the keyword does not name one, because Instagram truncates button titles at
+ * 20 characters and a bilingual label would arrive cut mid-word.
+ */
+export function pickLabel(
+  label: string | null | undefined,
+  lang: Lang | null | undefined
+): string {
+  if (!label) return label ?? "";
+  return pickLanguage(label, lang, "first");
+}


### PR DESCRIPTION
## The problem

A campaign aimed at a bilingual audience has to write every message twice — one half per language — and then send **both** halves to everyone. The reader scrolls past the half they cannot read, in the public reply, the opening DM, the follow gate and the final message alike.

## The change

The keyword that matched the comment picks the language. `matchKeywords()` already returned `matchedKeyword`; it only had to reach the send.

Messages stay written once, with each half opened by its flag:

```
🇮🇹 Ciao, vuoi scaricare gli sfondi?

🇺🇸 Hi! Are you interested in the wallpapers?
```

`pickLanguage()` cuts on the flags and is applied inside the two rendering functions in `lib/tracking/message.ts`, so a single place covers public reply, opening DM, follow gate and final message.

**Which keyword means which language is configuration, not code.** `KEYWORD_LANGUAGES` maps them (documented in `.env.example`):

```
KEYWORD_LANGUAGES=sfondi:it,wallpaper:en,wallpapers:en
```

Unset by default, so **this changes nothing for anyone who does not opt in**: an unmapped keyword — or an "any word" campaign — leaves the language null and the whole message goes out exactly as it does today. Six languages are supported (it, en, es, fr, de, pt), one flag each; a malformed pair in the variable is skipped rather than thrown, so a typo degrades to the current behaviour instead of breaking the worker.

## Two non-obvious details

- **`{link}` is written at the bottom**, after the last half, so a naive cut left every reader but the last one without a link. Neutral tokens are re-attached to the half that lost them.
- **Pressing the follow gate button, the comment is out of the picture** and the language would be lost halfway through, so it travels in the payload: `reveal:<id>:it`. The suffix is optional and the parser accepts both forms, so buttons already sent stay valid.

Button labels go through `pickLabel()`, which narrows to a single language even without a known keyword: Instagram truncates button titles at 20 characters, and a bilingual label would arrive cut mid-word.

## Checks

`npm run typecheck`, `npm run lint`, `npm test`, `npm run build` all pass. 12 new tests in `__tests__/language.test.ts` (154 total, up from 142) cover the malformed map, an absent language, a non-bilingual message, the trailing `{link}`, a third language and the button labels.

Not exercised against the live Meta API — the message rendering and the payload round-trip are covered by unit tests only.

## Credit

The idea and the first implementation are [Fabiano](https://github.com/ispazio)'s, in `ispazio/openreply@484e675`. This port replaces the hardcoded keyword map and campaign defaults with configuration so it fits any account, not just his.