### PR TITLE
Match a comment left on an ad to the post the ad was made from

### DIFF
--- a/__tests__/dm-worker.test.ts
+++ b/__tests__/dm-worker.test.ts
@@ -185,7 +185,7 @@ function getProcessor(): (job: {
   }) => Promise<void>;
 }
 
-function createMockJob(data = mockJobData) {
+function createMockJob(data: Record<string, unknown> = mockJobData) {
   return {
     data,
     id: "job_001",
@@ -273,6 +273,36 @@ beforeEach(() => {
     message_id: "msg_006",
   });
   mockGetUserFollowStatus.mockResolvedValue(true);
+});
+
+describe("DM Worker — comments left on an ad", () => {
+  it("also matches the organic post the ad was created from", async () => {
+    const processor = getProcessor();
+
+    // A boosted post: the comment carries the ad's media id, while the
+    // campaign is bound to the post the ad was made from. Without the second
+    // id in the query the comment matches nothing and is dropped silently.
+    await processor(
+      createMockJob({
+        ...mockJobData,
+        mediaId: "ad_media_999",
+        originalMediaId: "media_101",
+      })
+    );
+
+    expect(mockPrisma.automation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { postId: "ad_media_999" },
+            { postId: "media_101" },
+            { matchAnyPost: true },
+          ],
+        }),
+      })
+    );
+    expect(mockSendPrivateReply).toHaveBeenCalled();
+  });
 });
 
 describe("DM Worker — Full Pipeline", () => {

--- a/__tests__/webhook.test.ts
+++ b/__tests__/webhook.test.ts
@@ -99,6 +99,66 @@ describe("parseCommentEvents", () => {
     });
   });
 
+  it("keeps the organic post id of a comment left on an ad", () => {
+    const payload = {
+      object: "instagram",
+      entry: [
+        {
+          id: "page_123",
+          time: 1234567890,
+          changes: [
+            {
+              field: "comments",
+              value: {
+                id: "comment_456",
+                text: "Link",
+                from: { id: "user_789", username: "testuser" },
+                // A boosted post: the comment carries the ad's own media id,
+                // while the campaign is bound to the post it was made from.
+                media: {
+                  id: "ad_media_999",
+                  ad_id: "ad_123",
+                  original_media_id: "media_101",
+                  media_product_type: "AD",
+                },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const events = parseCommentEvents(payload);
+    expect(events).toHaveLength(1);
+    expect(events[0].mediaId).toBe("ad_media_999");
+    expect(events[0].originalMediaId).toBe("media_101");
+  });
+
+  it("leaves originalMediaId unset when it repeats the media id", () => {
+    const payload = {
+      object: "instagram",
+      entry: [
+        {
+          id: "page_123",
+          time: 1234567890,
+          changes: [
+            {
+              field: "comments",
+              value: {
+                id: "comment_456",
+                text: "Link",
+                from: { id: "user_789", username: "testuser" },
+                media: { id: "media_101", original_media_id: "media_101" },
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(parseCommentEvents(payload)[0].originalMediaId).toBeUndefined();
+  });
+
   it("should ignore non-instagram objects", () => {
     const payload = {
       object: "page",

--- a/app/api/webhook/route.ts
+++ b/app/api/webhook/route.ts
@@ -99,6 +99,7 @@ export async function POST(request: NextRequest) {
           commenterId: event.commenterId,
           commenterName: event.commenterName,
           mediaId: event.mediaId,
+          originalMediaId: event.originalMediaId,
           source: "WEBHOOK",
         },
         {

--- a/lib/meta/webhook.ts
+++ b/lib/meta/webhook.ts
@@ -39,6 +39,12 @@ export interface WebhookCommentEvent {
   commenterId: string;
   commenterName?: string;
   mediaId: string;
+  /**
+   * Set only when the comment was left on an ad: the id of the organic post
+   * the ad was created from. Campaigns are configured against that post, so
+   * matching has to consider it as well as mediaId.
+   */
+  originalMediaId?: string;
 }
 
 interface WebhookEntry {
@@ -56,6 +62,11 @@ interface WebhookEntry {
       };
       media?: {
         id?: string;
+        // Present when media_product_type is "AD": the ad copy gets its own
+        // media id, and this points back to the post it was boosted from.
+        original_media_id?: string;
+        ad_id?: string;
+        media_product_type?: string;
       };
       media_id?: string;
     };
@@ -115,6 +126,13 @@ export function parseCommentEvents(payload: WebhookPayload): WebhookCommentEvent
       const value = change.value;
       const commentId = value?.id ?? value?.comment_id;
       const mediaId = value?.media?.id ?? value?.media_id;
+      // A comment on a boosted post arrives with the ad's media id, while the
+      // campaign is set up against the organic post. Keep both so the worker
+      // can match either one.
+      const originalMediaId =
+        value?.media?.original_media_id === mediaId
+          ? undefined
+          : value?.media?.original_media_id;
       const commenterId = value?.from?.id;
 
       if (!entry.id || !commentId || !mediaId || !commenterId) {
@@ -135,6 +153,7 @@ export function parseCommentEvents(payload: WebhookPayload): WebhookCommentEvent
         commenterId,
         commenterName: value.from?.username,
         mediaId,
+        originalMediaId,
       });
     }
   }

--- a/lib/queue/client.ts
+++ b/lib/queue/client.ts
@@ -29,6 +29,9 @@ export interface ProcessCommentJob {
   commenterId: string;
   commenterName?: string;
   mediaId: string;
+  // Set when the comment came from an ad: the organic post the ad was made
+  // from. Campaigns are bound to that post, so both ids have to be matched.
+  originalMediaId?: string;
   requeueAttempt?: number;
   // Which path enqueued this comment. Recorded in the shared ProcessedComment
   // dedup store so the reconciler can tell webhook- from polling-caught comments.

--- a/lib/queue/dm-worker.ts
+++ b/lib/queue/dm-worker.ts
@@ -196,13 +196,21 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
     commenterId,
     commenterName,
     mediaId,
+    originalMediaId,
   } = job.data;
   const requeueAttempt = job.data.requeueAttempt ?? 0;
 
   const automations = await prisma.automation.findMany({
     where: {
       // Match campaigns bound to this specific post, plus any-post campaigns.
-      OR: [{ postId: mediaId }, { matchAnyPost: true }],
+      // A comment left on an ad carries the ad's own media id, while the
+      // campaign is bound to the post the ad was created from, so both ids
+      // have to be considered or the comment is dropped without a trace.
+      OR: [
+        { postId: mediaId },
+        ...(originalMediaId ? [{ postId: originalMediaId }] : []),
+        { matchAnyPost: true },
+      ],
       isActive: true,
       instagramAccount: {
         instagramId: instagramAccountId,


### PR DESCRIPTION
## The bug

Boost a post, and its campaign stops working. A comment left on the ad never triggers anything: no DM, no public reply, and **nothing in `DmLog`** — not a failed send, not an error, no trace at all. From the dashboard it looks like the comment never happened.

Here is the webhook Instagram actually sends for a comment on a boosted post (real payload, ids shortened):

```json
{
  "field": "comments",
  "value": {
    "id": "18101088227611337",
    "from": { "username": "…" },
    "text": "Link",
    "media": {
      "id": "17899788633163100",
      "ad_id": "120250706469160200",
      "original_media_id": "18023946917554990",
      "media_product_type": "AD"
    }
  }
}
```

The ad gets its **own** media id. The campaign is bound to `original_media_id`, the post the ad was created from.

`lib/meta/webhook.ts` reads only the first one:

```ts
const mediaId = value?.media?.id ?? value?.media_id;
```

so the lookup in `lib/queue/dm-worker.ts` compares the ad's id against the campaign's `postId`, matches nothing, and drops the comment silently.

The polling reconciler cannot rescue it either: it asks for the comments of the organic media, and these live on a different one.

## The fix

Carry both ids and match either:

```ts
OR: [
  { postId: mediaId },
  ...(originalMediaId ? [{ postId: originalMediaId }] : []),
  { matchAnyPost: true },
],
```

`originalMediaId` is left unset when it merely repeats `media.id`, so an ordinary comment produces exactly the query it produced before — the change is inert for anyone who does not run ads.

## Verification

`npm run typecheck`, `npm run lint`, `npm test`, `npm run build` all pass. Three new tests cover the ad payload, the id-repeats-itself case, and the worker query.

Beyond the unit tests, this ran against a live account: a real comment that had been lost this way was replayed through a patched instance, and the private reply went out and was logged as `SENT`. So Meta does accept a private reply for a comment left on an ad — the only thing that was broken was the matching.