### PR TITLE
Run the cron jobs when self-hosting, where nothing runs them

### DIFF
--- a/docs/deploy-dokploy.md
+++ b/docs/deploy-dokploy.md
@@ -63,6 +63,45 @@ Error: P1001: Can't reach database server at `<db-service-name>:5432`
 
 if you try to run migrations as part of the build (e.g. via the `vercel-build` script, which bundles `prisma generate && prisma migrate deploy && next build` together). The fix is the build/start command split shown above — `prisma generate` and `next build` happen at build time (no DB needed), while `prisma migrate deploy` runs in the start command, once the container is actually live and on the network.
 
+## Gotcha #4 — Nothing runs the cron jobs
+
+The three jobs under `/api/cron` are scheduled by the `crons` block in
+`vercel.json`. Nothing outside Vercel reads that file, so on a self-hosted
+instance they simply never run — and none of them fails loudly:
+
+- **`refresh-tokens`** is the one that hurts. The Instagram token expires and
+  every automation stops, with no error anywhere: comments keep arriving and
+  nothing answers them.
+- **`attach-next-reel`** binds a campaign created ahead of time to the reel
+  published after it. Without it, a "next reel" campaign stays inert forever.
+- **`snapshot-followers`** keeps the follower history, which Instagram only
+  retains for ~30 days.
+
+**Fix:** run `scripts/cron.sh` as a fourth service, from the same image as the
+web app — the same pattern as the worker, so the jobs live and die with the app
+they belong to:
+
+```yaml
+  cron:
+    image: <same image as web>
+    restart: unless-stopped
+    command: ["sh", "scripts/cron.sh"]
+    environment:
+      CRON_BASE_URL: http://web:3000
+      CRON_SECRET: ${CRON_SECRET}
+    depends_on:
+      web:
+        condition: service_healthy
+```
+
+`condition: service_healthy` matters: started alone, the first run fires while
+the web app is still booting and dies on connection refused.
+
+The script calls `attach-next-reel` every five minutes and the other two once a
+day. Five minutes is deliberate — on Vercel this runs daily, which means a
+campaign prepared before publishing stays inactive for the whole first evening,
+when most of the comments arrive.
+
 ## Step-by-step
 
 1. Fork this repo.
@@ -72,6 +111,7 @@ if you try to run migrations as part of the build (e.g. via the `vercel-build` s
 5. Assign a domain to the web app only (not the worker) in Dokploy's Domains section, container port `3000`. This becomes your `NEXTAUTH_URL`.
 6. Repeat step 3 for a second Application — this is the worker. Use the worker's build/start commands from Gotcha #2, and the same full set of environment variables as the web app, especially `DATABASE_URL`, `REDIS_URL`, and `ENCRYPTION_KEY` (these three must match exactly between both apps, or DM sends will fail to decrypt).
 7. Deploy both apps.
-8. Check `https://your-domain/api/health` — confirms database, Redis, queue, and worker heartbeat are all healthy.
+8. Add the cron service from Gotcha #4, so the scheduled jobs actually run.
+9. Check `https://your-domain/api/health` — confirms database, Redis, queue, and worker heartbeat are all healthy.
 
 From here, the Meta app setup, OAuth redirect, and webhook configuration are identical to the standard setup in `docs/setup.md`.

--- a/scripts/cron.sh
+++ b/scripts/cron.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Scheduler for the periodic jobs under /api/cron.
+#
+# On Vercel these run from the "crons" block in vercel.json. Nothing reads that
+# file anywhere else, so a self-hosted instance has no scheduler at all and the
+# jobs simply never run — silently. The one that hurts is refresh-tokens: the
+# Instagram token expires and every automation stops without a single error.
+#
+# Run as its own container from the app image (see the compose file), so the
+# jobs live with the app they belong to and keep working even if every other
+# stack on the host is taken down.
+
+set -u
+
+BASE_URL="${CRON_BASE_URL:-http://web:3000}"
+# Same fallback as the routes themselves: they accept either secret.
+SECRET="${CRON_SECRET:-${NEXTAUTH_SECRET:-}}"
+
+if [ -z "$SECRET" ]; then
+  echo "[cron] neither CRON_SECRET nor NEXTAUTH_SECRET is set — the routes would answer 401" >&2
+  exit 1
+fi
+
+call() {
+  route="$1"
+  stamp=$(date -u '+%Y-%m-%d %H:%M:%S')
+
+  if body=$(wget -q -O- --timeout=180 \
+      --header="Authorization: Bearer $SECRET" \
+      "$BASE_URL/api/cron/$route" 2>&1); then
+    echo "[cron] $stamp $route ok $body"
+  else
+    # A failure is worth shouting about: these jobs have no user watching them.
+    echo "[cron] $stamp $route FAILED ${body:-no response}" >&2
+  fi
+}
+
+echo "[cron] scheduler started, target $BASE_URL"
+
+last_slot=""
+last_daily=""
+
+while true; do
+  now=$(date -u '+%Y-%m-%d %H:%M')
+  today=${now% *}
+  hhmm=${now#* }
+  hour=${hhmm%:*}
+  minute=${hhmm#*:}
+
+  # attach-next-reel every 5 minutes rather than once a day: a campaign created
+  # before its reel is published stays inert until this binds it, and a daily
+  # run would cost the whole first evening of comments.
+  case "$minute" in
+    00|05|10|15|20|25|30|35|40|45|50|55)
+      if [ "$last_slot" != "$hhmm" ]; then
+        last_slot="$hhmm"
+        call attach-next-reel
+      fi
+      ;;
+  esac
+
+  # Once a day, early: the token refresh has a 10-day window before expiry, so
+  # the exact hour does not matter — only that it happens every day.
+  if [ "$hour" = "05" ] && [ "$last_daily" != "$today" ]; then
+    last_daily="$today"
+    call refresh-tokens
+    call snapshot-followers
+  fi
+
+  # Half a minute: short enough never to skip a slot, long enough to stay idle.
+  sleep 30
+done


### PR DESCRIPTION
The three jobs under `/api/cron` are scheduled by the `crons` block in `vercel.json`. Nothing outside Vercel reads that file, so a self-hosted instance has no scheduler at all — and none of the three fails loudly, which is what makes it easy to miss.

I found this on a NAS deployment where the jobs had **never run once** since the instance was set up.

What each one costs when it never runs:

- **`refresh-tokens`** — the one that hurts. The Instagram token expires and every automation stops, with no error anywhere: comments keep arriving and nothing answers them.
- **`attach-next-reel`** — a campaign created with "next reel" stays bound to no post, forever.
- **`snapshot-followers`** — follower history is lost, and Instagram only retains ~30 days of it.

## What this adds

`scripts/cron.sh`, run as a fourth service from the app image — the same shape as the worker, so the jobs live and die with the app they belong to rather than depending on something else on the host. Plus a "Gotcha #4" section in `docs/deploy-dokploy.md`, matching the style of the existing ones.

Two details worth flagging:

- **`attach-next-reel` runs every five minutes**, not daily as on Vercel. A campaign prepared before publishing would otherwise sit inactive through the whole first evening, which is when most comments arrive.
- The compose snippet uses `depends_on: condition: service_healthy`. With `service_started` the first run fires while the web app is still booting and dies on connection refused — which then looks like a broken script rather than a race.

The script uses `wget` and `sh` only, so it runs on the same Alpine-based image without extra packages, and it accepts `CRON_SECRET` or `NEXTAUTH_SECRET` — the same fallback the routes themselves use.
