### PR TITLE
Fix Instagram OAuth: authorize on www.instagram.com, not the retired api.instagram.com

### DIFF
--- a/lib/meta/oauth.ts
+++ b/lib/meta/oauth.ts
@@ -7,7 +7,12 @@ import {
 } from "crypto";
 import { getEncryptionKeyHex, requireEnv } from "@/lib/env";
 
-const INSTAGRAM_OAUTH_URL = "https://api.instagram.com/oauth/authorize";
+// Instagram API with Instagram Login authorizes on www.instagram.com. The old
+// api.instagram.com/oauth/authorize host belonged to the retired Basic Display
+// API and now 404s ("Sorry, this page isn't available"), which looks like a bad
+// link rather than a wrong endpoint. The token exchange below still lives on
+// api.instagram.com — only the authorize hop moved.
+const INSTAGRAM_OAUTH_URL = "https://www.instagram.com/oauth/authorize";
 const INSTAGRAM_TOKEN_URL = "https://api.instagram.com/oauth/access_token";
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;


### PR DESCRIPTION
Possibly the cause of #2 ("Error trying to connect my IG account"), which has several people reporting the same thing with no root cause found yet. I hit it on a fresh self-host tonight and tracked it down.

## Symptom

Clicking **Connect Instagram** never reaches the consent screen. Instagram shows:

> Sorry, this page isn't available.

There is no redirect back, so the callback never runs and **nothing is logged anywhere** — `WebhookEvent`, `DmLog`, and `OperationalEvent` all stay empty. It reads like a broken link rather than a wrong endpoint, which is what makes it expensive to find. Everything downstream looks healthy, so it's natural to go hunting through Meta app config instead.

## Cause

`lib/meta/oauth.ts` authorizes against `https://api.instagram.com/oauth/authorize`. That host belonged to the **Instagram Basic Display API**, which Meta has retired.

**Instagram API with Instagram Login** — the flow this project uses, and the one `docs/setup.md` Step 4 tells you to pick — authorizes on `https://www.instagram.com/oauth/authorize`.

The authoritative value is the Embed URL the Meta console generates for your own app, under **Instagram → API setup with Instagram login**:

```
https://www.instagram.com/oauth/authorize?force_reauth=true&client_id=…&redirect_uri=…
```

## The fix

One constant. Only the authorize hop moved — the token exchange still lives on `api.instagram.com/oauth/access_token`, so `INSTAGRAM_TOKEN_URL` is deliberately unchanged. I added a comment so the asymmetry doesn't read as a typo and get "corrected" later.

## Verification

Tested end to end on a fresh self-host — published Business app, verified business portfolio, Vercel web app + Railway worker:

- Consent screen renders (`instagram.com/consent/?flow=ig_biz_login_oauth`) with all four requested scopes
- Callback completes and stores the account with `user_id`, not the app-scoped `id`
- A keyword comment from a second account produced a **`SENT`** row in `DmLog`, with both the public reply and the DM delivered

`tsc --noEmit` clean, 142/142 tests passing.

## Two adjacent gotchas, not fixed here

Both cost me time on the same setup. Happy to send either as a separate docs PR if useful:

1. **Meta's "Add all required permissions" button under-delivers.** It reported success but only attached `instagram_business_basic` and `instagram_business_manage_messages`. `instagram_business_manage_comments` and `instagram_business_manage_insights` had to be added by hand from **Permissions and features**. Since `getAuthorizationUrl` requests all four scopes, a missing one is another way to break this flow — worth a line in `docs/setup.md` Step 5.

2. **The tester invite is far easier to find on the web.** `docs/setup.md` Step 6 describes the phone-app path (Settings and activity → Apps and websites → Tester invites). On current Instagram builds that was not discoverable for me, but `instagram.com/accounts/manage_access/` → **Tester Invites** tab shows it immediately with Accept/Decline.

Thanks for open-sourcing this — the Meta-quirks documentation in `docs/setup.md` saved me a lot of time elsewhere, particularly the "publishing is not Advanced Access" section from #17, which correctly diagnosed a separate `IGApiException` I hit right after this one.