### PR TITLE
fix: use www.instagram.com for OAuth authorize step

### DIFF
--- a/lib/meta/oauth.ts
+++ b/lib/meta/oauth.ts
@@ -7,7 +7,7 @@ import {
 } from "crypto";
 import { getEncryptionKeyHex, requireEnv } from "@/lib/env";
 
-const INSTAGRAM_OAUTH_URL = "https://api.instagram.com/oauth/authorize";
+const INSTAGRAM_OAUTH_URL = "https://www.instagram.com/oauth/authorize";
 const INSTAGRAM_TOKEN_URL = "https://api.instagram.com/oauth/access_token";
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 16;


### PR DESCRIPTION
## Summary
- Meta migrated the Instagram Login product's OAuth consent screen from `api.instagram.com/oauth/authorize` to `www.instagram.com/oauth/authorize`. Apps still pointed at `api.instagram.com` get a generic "Sorry, this page isn't available" error instead of the consent screen.
- Updates `INSTAGRAM_OAUTH_URL` in `lib/meta/oauth.ts` to the new host. Token exchange (`INSTAGRAM_TOKEN_URL`, still `api.instagram.com/oauth/access_token`) is unaffected.

## Test plan
- [ ] Start OAuth flow from the dashboard, confirm the Instagram consent screen loads (no more "Sorry, this page isn't available")
- [ ] Complete authorization and confirm the callback + token exchange still succeed