### PR TITLE
docs: document the messages webhook field, and that OpenReply is self-hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Someone comments `LINK` on your reel, and they get a DM with your link a second 
 
 ManyChat does this and charges a monthly fee. OpenReply is the same core feature, free, running on your own infrastructure, with no seat limits and no plan caps.
 
+> **OpenReply is self-hosted. You have to deploy your own copy.**
+>
+> [openreply.diwen.dev](https://openreply.diwen.dev) is a demo of the dashboard, not a service you can sign up for. Creating an account there will never send a DM for you, and there is no hosted plan to upgrade to.
+>
+> Instagram automation runs against *your* Meta app, and Meta ties that app to a domain and a webhook URL you control. So a working instance means: your fork deployed, your domain pointed at it, your Meta app created, and your webhook registered. [docs/setup.md](docs/setup.md) walks through all of it.
+
 > If this saves you a subscription or a weekend of building, a star on the repo genuinely helps other people find it.
 
 ## Why this exists
@@ -26,6 +32,7 @@ OpenReply is built around Meta's official Instagram private replies. It does not
 
 - Keyword to DM. Match one or many keywords per post, whole-word or partial.
 - Optional public reply. Post a visible comment reply on top of the DM.
+- DM and Story reply triggers. The same keywords can also fire on an inbound DM, which covers text replies to your Stories, since Instagram delivers those as DMs. That makes `Reply LINK to this Story` work with no post involved. Turn it on per campaign, and subscribe to the `messages` webhook field when you set up your Meta app.
 - Tracked links. Swap a link for a tracked redirect and see clicks and CTR per campaign.
 - Two link buttons. Send up to two tappable link buttons in one DM, each a separate tracked link with its own click stats.
 - Follow gate. Optionally require a follow before you hand over the link. The DM asks the commenter to follow and tap a button; on tap, OpenReply checks Meta's `is_user_follow_business` flag and only sends the link once they follow, re-prompting until then. It fails open (sends the link anyway) when Instagram does not return follow status, so a real follower is never trapped.
@@ -40,9 +47,9 @@ OpenReply is built around Meta's official Instagram private replies. It does not
 
 ## How it works
 
-1. Someone comments on your Instagram post or reel.
+1. Someone comments on your Instagram post or reel, or DMs you, or replies to your Story.
 2. Meta sends a webhook to your OpenReply instance.
-3. OpenReply checks the comment against your active campaigns.
+3. OpenReply checks the text against your active campaigns.
 4. On a keyword match, it queues a job.
 5. A background worker sends the private reply, and the public reply if you enabled one.
 
@@ -55,6 +62,8 @@ You need a few free accounts before anything works: a Meta developer app, a Rese
 The honest version: the code deploys in minutes, but the Meta app setup is the part that takes real time. Read [docs/setup.md](docs/setup.md) before you start. It is the single setup guide, covering hosting, your domain, the environment, and every Meta wrong turn so you do not have to find them yourself.
 
 ### Deploy the web app
+
+This is the part people skip. There is no shared instance to join — the button below creates *your* deployment, on *your* domain, which is the only thing your Meta app is allowed to talk to.
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/diwenne/openreply)
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
 };
 
 const GITHUB_URL = "https://github.com/diwenne/openreply";
+const SETUP_DOCS_URL =
+  "https://github.com/diwenne/openreply/blob/main/docs/setup.md";
 
 function formatStars(count: number): string {
   if (count >= 1000) {
@@ -345,6 +347,28 @@ export default async function Home() {
             </a>
           </div>
 
+          <div className="mt-5 max-w-2xl border-l-4 border-orange-500 bg-orange-50 px-4 py-3 text-sm leading-6 text-zinc-700">
+            <span className="font-bold text-zinc-900">
+              Deploy your own copy first.
+            </span>{" "}
+            This site is a demo. Your automations cannot run on{" "}
+            <code className="bg-white px-1 py-0.5 font-mono text-xs text-zinc-900">
+              openreply.diwen.dev
+            </code>{" "}
+            — OpenReply needs your own Meta app, your own domain, and a webhook
+            pointed at it, so signing in here will not send DMs for your
+            account.{" "}
+            <a
+              href={SETUP_DOCS_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="font-bold text-orange-700 underline underline-offset-2 transition hover:text-orange-800"
+            >
+              Read the setup guide
+            </a>
+            .
+          </div>
+
           <dl className="mt-10 grid max-w-xl grid-cols-3 gap-3">
             {heroStats.map((stat) => (
               <div key={stat.label} className="border border-zinc-200 bg-zinc-50 p-4">
@@ -443,6 +467,22 @@ export default async function Home() {
             </h2>
             <p className="mt-4 text-base text-zinc-600">
               Free and open source. Star it if it saves you a subscription.
+            </p>
+            <p className="mt-3 text-sm leading-6 text-zinc-600">
+              <span className="font-bold text-zinc-900">
+                On your own deployment, not this one.
+              </span>{" "}
+              Clone the repo and follow the{" "}
+              <a
+                href={SETUP_DOCS_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="font-bold text-orange-700 underline underline-offset-2 transition hover:text-orange-800"
+              >
+                setup guide
+              </a>{" "}
+              — a Meta app and a domain of your own are required before anything
+              sends.
             </p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row lg:flex-col">

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -176,7 +176,9 @@ Still in the Instagram product, find the Configure webhooks step.
 - Callback URL: `https://your-app.vercel.app/api/webhook`
 - Verify token: the value of `WEBHOOK_VERIFY_TOKEN` from your environment
 - Click Verify and save. It should succeed immediately, because the app answers Meta's verification challenge. If the button is greyed out, click into the verify-token field and paste the token again; editing the callback URL often clears it.
-- Subscribe to the `comments` field.
+- Subscribe to the `comments` field, and to `messages` as well.
+
+Both fields matter. `comments` carries comment-to-DM, which is what most people come here for. `messages` carries inbound DMs and Story replies, which is what a campaign's "also reply when someone DMs these words" toggle runs on. Subscribe to `comments` alone and that toggle looks enabled but never fires, because the events it needs are never delivered.
 
 To test delivery without a real comment, click Test next to `comments`, then click Send to My Server. This is a two-step control. Clicking Test only previews the sample payload; the second button is what actually POSTs it to your endpoint. After sending, a row should appear in your `WebhookEvent` table.
 


### PR DESCRIPTION
Two things that were true in the code but absent from the docs, both of which cost people their first working DM.

### 1. The `messages` webhook field was never documented

`docs/setup.md` step 8 told you to subscribe to the `comments` field, and stopped there. `messages` is not mentioned in the setup guide, the README, or `META_APP_REVIEW.md`.

That means anyone who followed the guide has an instance where a campaign's **"also reply when someone DMs these words"** toggle appears enabled and silently never fires, because the events it needs are never delivered.

It is also the answer to #7. Instagram delivers a text reply to a Story as an ordinary DM on the `messages` webhook, and `parseMessageEvents` does not filter those out, so Story reply keyword automations already work end to end once the field is subscribed — case-insensitive matching, echoes and self-sent messages dropped, deduped per message id. It just looked unimplemented because nobody was told to subscribe.

Two items from that issue are genuinely not implemented and are better tracked separately: Story reply runs are not labelled distinctly in the logs, and a campaign cannot be scoped to Story replies only.

### 2. Nothing said openreply.diwen.dev is a demo

There is no hosted plan, and signing in on the demo will never send a DM for you — Instagram automation runs against *your* Meta app, which Meta ties to a domain and webhook URL you control. That was only implicit before.

## Changes

- **`docs/setup.md`** — step 8 now subscribes to `comments` **and** `messages`, with a note on what breaks if you only do the first.
- **`README.md`** — new Features bullet for the DM and Story reply trigger; "How it works" steps 1 and 3 corrected, since they claimed comments were the only entry point; a self-hosting callout above the fold, and a line above the Vercel deploy button.
- **`app/page.tsx`** — an alert under the hero "Get started" CTA and a shorter one at the closing CTA, both linking to the setup guide.

## Verification

`tsc --noEmit` and `eslint app/page.tsx` are clean. The landing page was rendered against a local dev server to confirm the hero alert sits correctly under the CTA and does not collide with the floating comment card.

Closes #7
