### PR TITLE
feat(landing): move the demo notice to a dismissible banner, and add it to the login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 import { EMAIL_PROVIDER_ID, signIn } from "@/lib/auth";
 import { getCampaignTemplate } from "@/lib/templates/campaign-templates";
+import { DemoNotice } from "@/components/demo-notice";
 
 export const metadata = {
   title: "Login - OpenReply",
@@ -44,6 +45,8 @@ export default async function LoginPage({
               : "Sign in by email, then connect your Instagram professional account."}
           </p>
         </div>
+
+        <DemoNotice variant="panel" />
 
         <div className="panel rounded p-8 shadow-black/40">
           {selectedTemplate && !checkEmail && (

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 import Link from "next/link";
+import { DemoNotice } from "@/components/demo-notice";
 
 export const metadata: Metadata = {
   title: "OpenReply - Open source Instagram comment-to-DM automation",
@@ -287,6 +288,8 @@ export default async function Home() {
   const stars = await getGitHubStars();
   return (
     <main className="min-h-screen bg-white text-zinc-900">
+      <DemoNotice variant="banner" />
+
       <header className="sticky top-0 z-40 border-b border-zinc-200 bg-white">
         <div className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-5 sm:px-6 lg:px-8">
           <Link href="/" className="flex items-center gap-3" aria-label="OpenReply home">
@@ -345,28 +348,6 @@ export default async function Home() {
             >
               See how it works
             </a>
-          </div>
-
-          <div className="mt-5 max-w-2xl border-l-4 border-orange-500 bg-orange-50 px-4 py-3 text-sm leading-6 text-zinc-700">
-            <span className="font-bold text-zinc-900">
-              Deploy your own copy first.
-            </span>{" "}
-            This site is a demo. Your automations cannot run on{" "}
-            <code className="bg-white px-1 py-0.5 font-mono text-xs text-zinc-900">
-              openreply.diwen.dev
-            </code>{" "}
-            — OpenReply needs your own Meta app, your own domain, and a webhook
-            pointed at it, so signing in here will not send DMs for your
-            account.{" "}
-            <a
-              href={SETUP_DOCS_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="font-bold text-orange-700 underline underline-offset-2 transition hover:text-orange-800"
-            >
-              Read the setup guide
-            </a>
-            .
           </div>
 
           <dl className="mt-10 grid max-w-xl grid-cols-3 gap-3">

--- a/components/demo-notice.tsx
+++ b/components/demo-notice.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * The public demo, and the only host this notice ever appears on. This repo is
+ * something other people clone and deploy, and a self-hoster's instance is not
+ * a demo — naming this domain on their site would tell their visitors the
+ * opposite of the truth.
+ */
+const DEMO_HOST = "openreply.diwen.dev";
+
+const DISMISS_KEY = "openreply:demo-notice-dismissed";
+const SETUP_DOCS_URL =
+  "https://github.com/diwenne/openreply/blob/main/docs/setup.md";
+
+/// Module-level so both variants agree, and so dismissing survives a
+/// client-side navigation between the landing page and the login page.
+let dismissed: boolean | null = null;
+let listeners: Array<() => void> = [];
+
+function isDismissed(): boolean {
+  if (dismissed === null) {
+    try {
+      dismissed = window.localStorage.getItem(DISMISS_KEY) === "1";
+    } catch {
+      // Storage can throw in private modes. Showing the notice is the safe side.
+      dismissed = false;
+    }
+  }
+  return dismissed;
+}
+
+function subscribe(onChange: () => void) {
+  listeners.push(onChange);
+  return () => {
+    listeners = listeners.filter((listener) => listener !== onChange);
+  };
+}
+
+/// The host is only knowable in the browser, so the server snapshot is always
+/// false. Rendering on the server instead would flash the notice onto every
+/// instance that is not the demo.
+function getSnapshot(): boolean {
+  return window.location.hostname === DEMO_HOST && !isDismissed();
+}
+
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+function dismiss() {
+  dismissed = true;
+  try {
+    window.localStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // Dismissal simply does not persist if storage is unavailable.
+  }
+  for (const listener of listeners) listener();
+}
+
+export function DemoNotice({ variant }: { variant: "banner" | "panel" }) {
+  const visible = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
+
+  if (!visible) return null;
+
+  if (variant === "banner") {
+    return (
+      <div className="relative border-b border-orange-200 bg-orange-50">
+        <p className="mx-auto w-full max-w-6xl px-10 py-2 text-center text-xs leading-5 text-zinc-700 sm:px-14 sm:text-sm">
+          <span className="font-bold text-zinc-900">{DEMO_HOST}</span> is a
+          demo. OpenReply is self-hosted — signing in here will not send DMs for
+          your account.{" "}
+          <a
+            href={SETUP_DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="font-bold text-orange-700 underline underline-offset-2 transition hover:text-orange-800"
+          >
+            Deploy your own copy
+          </a>
+          .
+        </p>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss demo notice"
+          className="absolute right-2 top-1/2 -translate-y-1/2 p-2 text-zinc-500 transition hover:text-zinc-900 sm:right-4"
+        >
+          <DismissIcon />
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative mb-5 rounded border border-warning/30 bg-warning/10 px-4 py-3 pr-10">
+      <p className="text-sm leading-6 text-foreground">
+        <span className="font-semibold">{DEMO_HOST} is a demo instance.</span>{" "}
+        Signing in here will not send DMs for your Instagram account. OpenReply
+        is self-hosted, so it only works on a deployment you run yourself, with
+        your own Meta app and your own domain.{" "}
+        <a
+          href={SETUP_DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="font-semibold text-warning underline underline-offset-2"
+        >
+          Read the setup guide
+        </a>
+        .
+      </p>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label="Dismiss demo notice"
+        className="absolute right-1 top-1 p-2 text-muted transition hover:text-foreground"
+      >
+        <DismissIcon />
+      </button>
+    </div>
+  );
+}
+
+function DismissIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      aria-hidden="true"
+      className="h-3.5 w-3.5 stroke-current"
+      fill="none"
+      strokeWidth="2"
+      strokeLinecap="round"
+    >
+      <path d="M3 3l10 10M13 3L3 13" />
+    </svg>
+  );
+}


### PR DESCRIPTION
Follow-up to #30, which put a self-hosting notice on the landing page but not where it matters most.

"Get started" sends people to `/login`, and that page said nothing — so the one screen where someone is actively about to sign in gave no hint that signing in does nothing for them. This adds the notice there, shrinks the landing page version, and makes both dismissible.

## Changes

- **`components/demo-notice.tsx`** (new) — one client component, two variants: `banner` for the slim strip across the top of the landing page, `panel` for the box above the sign-in card.
- **`app/page.tsx`** — the block under the hero CTA is replaced by `<DemoNotice variant="banner" />` at the top of the page.
- **`app/login/page.tsx`** — `<DemoNotice variant="panel" />` above the sign-in card. It sits outside the panel, so it stays visible in the "Check your email" state too, which is exactly when someone assumes it worked.

## Only ever renders on openreply.diwen.dev

The notice names the domain now instead of saying "this site". That only works if it also knows when to keep quiet — this repo is meant to be cloned, and a hardcoded "openreply.diwen.dev is a demo, deploy your own copy" would otherwise render on every self-hosted instance, telling their visitors the opposite of the truth.

So it renders only when `window.location.hostname === "openreply.diwen.dev"`. Not on preview URLs, not on localhost, not on anyone else's deployment.

## Dismissal

An X on both variants. The flag goes to `localStorage` and is mirrored in module state, so dismissing on the landing page keeps it dismissed after a client-side navigation to login.

Visibility comes from `useSyncExternalStore` with a `false` server snapshot rather than an effect — hostname and dismissal are both browser-only facts. That avoids a hydration mismatch and stops the notice flashing onto instances that should never show it. (An effect-based version also trips `react-hooks/set-state-in-effect`.)

## Verification

`tsc --noEmit` and `eslint` clean. Both variants were rendered against a local dev server with the host check temporarily pointed at localhost, and both X buttons confirmed to remove the notice and persist the flag; that override was reverted before commit.

Note that because of the host check, this cannot be confirmed on the Vercel preview URL — only on production after deploy.
