### PR TITLE
Add Dockerfile for self-hosted Docker deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.git
+.env
+.env.local
+__tests__
+docs
+*.md

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,67 @@
+name: Build & Publish (Docker Hub)
+
+# Builda a imagem Docker (Dockerfile na raiz) e publica no Docker Hub.
+#
+# Secrets necessários no repositório (Settings → Secrets and variables → Actions):
+#   * DOCKERHUB_USERNAME  — usuário do Docker Hub (também vira o namespace)
+#   * DOCKERHUB_TOKEN     — Access Token do Docker Hub (Account Settings → Security)
+#
+# Triggers:
+#   * push na branch main  -> publica :latest e :sha-xxxx
+#   * push de tag vX.Y.Z   -> publica :vX.Y.Z e :latest
+#   * disparo manual (workflow_dispatch)
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: openreply
+
+jobs:
+  build-and-push:
+    name: Build & push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# OpenReply — self-hosted Docker image
+#
+# Two runtime processes ship from this image:
+#   - web:    `npm run start`  → next start (needs .next + node_modules)
+#   - worker: `npm run worker` → tsx worker/dm-worker.ts (runs RAW TypeScript,
+#             not a bundled output — needs the generated Prisma client, the
+#             full source tree under lib/ and worker/, and tsconfig.json for
+#             the `@/*` path alias tsx resolves at runtime)
+#
+# next.config.ts does not set `output: "standalone"`, so `next start` already
+# requires the full node_modules tree at runtime — there is no slimmer
+# standalone bundle to fall back to here. Given that, this Dockerfile does
+# NOT try to strip node_modules/tsconfig.json/source files out of the final
+# stage: doing so is exactly what breaks the worker (MODULE_NOT_FOUND on
+# `@/lib/...` imports, because tsx has no tsconfig to resolve the alias
+# against, and no app/generated/prisma to import from).
+
+FROM node:20-slim AS build
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+# `npm run build` = `prisma generate && next build` (see package.json) —
+# generates app/generated/prisma AND compiles .next/ in one step.
+RUN npm run build
+
+FROM node:20-slim AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/.next ./.next
+COPY --from=build /app/app/generated ./app/generated
+COPY --from=build /app/public ./public
+COPY --from=build /app/lib ./lib
+COPY --from=build /app/worker ./worker
+COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/prisma.config.ts ./prisma.config.ts
+COPY --from=build /app/next.config.ts ./next.config.ts
+COPY --from=build /app/tsconfig.json ./tsconfig.json
+COPY --from=build /app/package.json ./package.json
+
+EXPOSE 3000
+# Default to the web process — the worker service overrides this with
+# `command: ["npm", "run", "worker"]` in whatever compose/stack file deploys
+# it (see openreply-vps.stack.yml in EvolutionAPI/omni-nexus for an example).
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Why

The README says OpenReply is self-hosted, but there's no `Dockerfile` in the repo — only `docker-compose.yml`, which just spins up local dev Postgres/Redis. Anyone self-hosting today has to write their own image from scratch, and it's easy to get wrong: the worker (`npm run worker` → `tsx worker/dm-worker.ts`) runs raw TypeScript at runtime, not a bundled output like `next start` does, so it needs three things a naive multi-stage image tends to strip out:

1. the generated Prisma client (`app/generated/prisma`, produced by `prisma generate` at build time)
2. `tsconfig.json`, so `tsx` can resolve the `@/*` path alias used throughout `lib/` and `worker/`
3. the full `lib/` + `worker/` source tree

Miss any of those and the worker crashes on boot with `MODULE_NOT_FOUND` on the first `@/...` import it hits — it never processes a single queued DM.

## What this adds

- `Dockerfile` — two-stage build (deps+build, then a runtime stage that keeps `node_modules`, `.next`, the generated Prisma client, and the source tree the worker needs). `next.config.ts` doesn't set `output: "standalone"`, so `next start` already needs the full `node_modules` at runtime anyway — this doesn't try to slim that down.
- `.dockerignore`
- `.github/workflows/docker-publish.yml` — optional CI to build/push on push to `main`/tags, gated behind `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` repo secrets (no-op without them).

Both processes verified locally against the built image:
- `npm run start` → `HTTP 200`, clean `✓ Ready` log
- `npm run worker` → clean `[DM Worker] Started`, no `MODULE_NOT_FOUND` (only expected connection errors against a fake DB/Redis in the test)

## Context

Ran into this self-hosting OpenReply for a client project — happy to adjust the Dockerfile structure/base image if you have a preference (e.g. alpine vs slim, standalone output mode).