### PR TITLE
fix(docker): ship scripts/ and wget so the cron service can start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@
 #             not a bundled output — needs the generated Prisma client, the
 #             full source tree under lib/ and worker/, and tsconfig.json for
 #             the `@/*` path alias tsx resolves at runtime)
+#   - cron:   `sh scripts/cron.sh` → the scheduler for /api/cron, which nothing
+#             runs off Vercel (see docs/deploy-dokploy.md). It needs scripts/
+#             in the image and wget on PATH; node:20-slim ships neither.
 #
 # next.config.ts does not set `output: "standalone"`, so `next start` already
 # requires the full node_modules tree at runtime — there is no slimmer
@@ -30,6 +33,12 @@ FROM node:20-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 
+# scripts/cron.sh calls the /api/cron routes with wget, which node:20-slim does
+# not include.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends wget ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/.next ./.next
 COPY --from=build /app/app/generated ./app/generated
@@ -37,6 +46,7 @@ COPY --from=build /app/public ./public
 COPY --from=build /app/lib ./lib
 COPY --from=build /app/worker ./worker
 COPY --from=build /app/prisma ./prisma
+COPY --from=build /app/scripts ./scripts
 COPY --from=build /app/prisma.config.ts ./prisma.config.ts
 COPY --from=build /app/next.config.ts ./next.config.ts
 COPY --from=build /app/tsconfig.json ./tsconfig.json


### PR DESCRIPTION
The Dokploy guide tells self-hosters to run `scripts/cron.sh` as a fourth service from the app image:

```yaml
  cron:
    image: <same image as web>
    command: ["sh", "scripts/cron.sh"]
```

That service cannot start as written. The runner stage never copies `scripts/`, and `node:20-slim` does not include `wget`, which is what `cron.sh` calls the routes with. The container exits immediately.

It fails in the worst possible place, because `docs/deploy-dokploy.md` already explains why: one of the three jobs is `refresh-tokens`, so without it the Instagram token expires after 60 days and every automation stops **with no error anywhere**. Comments keep arriving and nothing answers them. A self-hoster who follows the guide exactly still ends up with a dead instance two months later.

## Change

- `COPY --from=build /app/scripts ./scripts` in the runner stage
- install `wget` and `ca-certificates`, cleaning the apt lists in the same layer
- note the third process in the header comment, next to web and worker

## Verification

Running in production on a Hostinger VPS with exactly these two additions, alongside n8n behind the same Traefik. The cron container has been calling the routes on schedule:

```
[cron] 2026-08-26 14:15:12 attach-next-reel ok {"success":true,"data":{"checked":0,"bound":0,"failedAccounts":0}}
[cron] 2026-08-26 14:20:12 attach-next-reel ok {"success":true,"data":{"checked":0,"bound":0,"failedAccounts":0}}
[cron] 2026-08-26 14:25:13 attach-next-reel ok {"success":true,"data":{"checked":0,"bound":0,"failedAccounts":0}}
```

And inside that container:

```
$ ls scripts/ && command -v wget
cron.sh
/usr/bin/wget
```

`wget` installs clean on `node:20-slim` (GNU Wget 1.21.3). Happy to swap the apt layer for a `node -e "fetch(...)"` call inside `cron.sh` instead if you would rather keep the image free of extra packages, but that changes the script for people running it outside Docker, so I went with the smaller diff.