### PR TITLE
fix(keyword-matcher): fold Latin diacritics so "PREÇO" matches a "preco" keyword

### DIFF
--- a/__tests__/keyword-matcher.test.ts
+++ b/__tests__/keyword-matcher.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect } from "vitest";
 import {
+  foldDiacritics,
   matchKeywords,
   stripSpecialCharacters,
 } from "../lib/utils/keyword-matcher";
@@ -176,5 +177,90 @@ describe("matchKeywords — edge cases", () => {
   it("should handle multi-word keywords", () => {
     const result = matchKeywords("I want more info please", ["more info"], true);
     expect(result.matched).toBe(true);
+  });
+});
+
+describe("foldDiacritics", () => {
+  it("should strip accents from Latin text", () => {
+    expect(foldDiacritics("preço")).toBe("preco");
+    expect(foldDiacritics("ÍNDICE")).toBe("INDICE");
+    expect(foldDiacritics("informação")).toBe("informacao");
+    expect(foldDiacritics("¿CUÁL?")).toBe("¿CUAL?");
+    expect(foldDiacritics("café crème")).toBe("cafe creme");
+  });
+
+  it("should treat precomposed and decomposed input identically", () => {
+    const precomposed = "\u00E9";
+    const decomposed = "e\u0301";
+    expect(foldDiacritics(precomposed)).toBe("e");
+    expect(foldDiacritics(decomposed)).toBe("e");
+  });
+
+  it("should leave non-Latin scripts untouched", () => {
+    // A combining mark is load bearing outside Latin, so the usual
+    // NFD-then-strip-\p{M} one-liner corrupts these. Folding must not.
+    expect(foldDiacritics("йод Клод Україна")).toBe("йод Клод Україна");
+    expect(foldDiacritics("Ελλάδα")).toBe("Ελλάδα");
+    expect(foldDiacritics("किताब")).toBe("किताब");
+    expect(foldDiacritics("สวัสดี")).toBe("สวัสดี");
+    expect(foldDiacritics("مَرْحَبًا")).toBe("مَرْحَبًا");
+  });
+
+  it("should not flip Japanese dakuten", () => {
+    // ガード (guard) would become カート (cart) under an unscoped fold.
+    expect(foldDiacritics("ガード")).toBe("ガード");
+  });
+
+  it("should leave text with no diacritics unchanged", () => {
+    expect(foldDiacritics("link")).toBe("link");
+    expect(foldDiacritics("")).toBe("");
+  });
+
+  it("should not fold ligatures, which are not diacritics", () => {
+    expect(foldDiacritics("Fußball")).toBe("Fußball");
+  });
+});
+
+describe("matchKeywords — diacritics", () => {
+  it("should match an accented comment against an unaccented keyword", () => {
+    expect(matchKeywords("PREÇO?", ["preco"], true).matched).toBe(true);
+    expect(matchKeywords("ÍNDICE", ["indice"], true).matched).toBe(true);
+    expect(matchKeywords("informação", ["informacao"], true).matched).toBe(
+      true
+    );
+  });
+
+  it("should match an unaccented comment against an accented keyword", () => {
+    expect(matchKeywords("preco por favor", ["preço"], true).matched).toBe(
+      true
+    );
+    expect(matchKeywords("cual es el precio", ["cuál"], true).matched).toBe(
+      true
+    );
+  });
+
+  it("should report the keyword as the campaign spelled it", () => {
+    const result = matchKeywords("Qual o PREÇO?", ["preco"], true);
+    expect(result.matched).toBe(true);
+    expect(result.matchedKeyword).toBe("preco");
+  });
+
+  it("should fold in partial mode too", () => {
+    expect(matchKeywords("precos hoje", ["preço"], false).matched).toBe(true);
+  });
+
+  it("should still respect whole-word boundaries after folding", () => {
+    expect(matchKeywords("apreco isso", ["preco"], true).matched).toBe(false);
+    expect(matchKeywords("apreço isso", ["preco"], true).matched).toBe(false);
+  });
+
+  it("should keep matching non-Latin keywords", () => {
+    expect(matchKeywords("дай Клод", ["клод"], true).matched).toBe(true);
+    expect(matchKeywords("ガードください", ["ガード"], false).matched).toBe(true);
+  });
+
+  it("should not match across different Cyrillic letters", () => {
+    // "йод" and "иод" are different words; an unscoped fold would conflate them.
+    expect(matchKeywords("иод", ["йод"], true).matched).toBe(false);
   });
 });

--- a/lib/utils/keyword-matcher.ts
+++ b/lib/utils/keyword-matcher.ts
@@ -13,6 +13,13 @@
  * matching, so a Russian keyword like "Клод" could never match. Everything
  * here uses Unicode property escapes (`\p{L}` letters, `\p{N}` numbers) with the
  * `u` flag so non-Latin scripts work.
+ *
+ * Diacritics note: `\p{L}` keeps accented letters intact, which is correct, but
+ * it means "PREÇO" and "preco" stay different strings and never match each
+ * other. Commenters type accents inconsistently and keyboards differ, so a
+ * Portuguese or Spanish campaign keyed on "preco" silently misses every
+ * commenter who typed "preço", and vice versa. `foldDiacritics` closes that
+ * gap on BOTH sides of the comparison.
  */
 
 export interface KeywordMatchResult {
@@ -37,7 +44,45 @@ export function stripSpecialCharacters(text: string): string {
 }
 
 /**
+ * Remove diacritics from Latin-script text, leaving every other script byte
+ * for byte identical.
+ *
+ * The scoping is the whole point and is not caution for its own sake. The
+ * usual one-liner, `text.normalize("NFD").replace(/\p{M}/gu, "")`, is wrong
+ * for a multi-script inbox because a combining mark is load bearing outside
+ * Latin: it deletes Devanagari vowel signs ("किताब" becomes "कतब"), strips
+ * Thai and Arabic vowel marks, folds Cyrillic "й" to "и" and Ukrainian "ї" to
+ * "і", and turns the Japanese dakuten in "ガード" into "カート", which is a
+ * different word. Only Latin marks are dropped here.
+ *
+ * Input is decomposed first so the function behaves the same whether the
+ * source text arrived precomposed (U+00E9) or decomposed (U+0065 U+0301);
+ * Instagram returns both.
+ */
+export function foldDiacritics(text: string): string {
+  let out = "";
+  let baseIsLatin = false;
+
+  for (const char of text.normalize("NFD")) {
+    if (/\p{M}/u.test(char)) {
+      // A mark inherits the script of the base character before it, so the
+      // base is what decides whether this mark is dropped or kept.
+      if (!baseIsLatin) out += char;
+      continue;
+    }
+    baseIsLatin = /\p{Script=Latin}/u.test(char);
+    out += char;
+  }
+
+  return out.normalize("NFC");
+}
+
+/**
  * Check if a comment text matches any of the given keywords.
+ *
+ * Both sides are stripped of special characters and folded for Latin
+ * diacritics before comparison, so "PREÇO" matches a "preco" keyword and a
+ * "preço" keyword matches a "PRECO" comment.
  *
  * @param commentText - The raw comment text to check
  * @param keywords - Array of keywords to match against
@@ -54,14 +99,18 @@ export function matchKeywords(
     return { matched: false, matchedKeyword: null };
   }
 
-  const cleanedText = stripSpecialCharacters(commentText).toLowerCase();
+  const cleanedText = foldDiacritics(
+    stripSpecialCharacters(commentText)
+  ).toLowerCase();
 
   if (!cleanedText) {
     return { matched: false, matchedKeyword: null };
   }
 
   for (const keyword of keywords) {
-    const cleanedKeyword = stripSpecialCharacters(keyword).toLowerCase();
+    const cleanedKeyword = foldDiacritics(
+      stripSpecialCharacters(keyword)
+    ).toLowerCase();
 
     if (!cleanedKeyword) continue;
 


### PR DESCRIPTION
## The bug

`stripSpecialCharacters` keeps `\p{L}`, which is correct, but it means an accented comment and an unaccented keyword stay different strings and never match. Measured against `main` (`c51f04d`), these all miss in **both** whole-word and partial mode:

| comment | keyword | result |
|---|---|---|
| `PREÇO?` | `preco` | miss |
| `ÍNDICE` | `indice` | miss |
| `informação` | `informacao` | miss |
| `¿CUÁL es el precio?` | `cual` | miss |

The reverse direction misses too: a campaign keyed on `preço` never matches a commenter who typed `preco`.

Accents get typed inconsistently, and mobile keyboards differ on how easy they are to reach, so for Portuguese, Spanish, French and German campaigns this drops real matches. It drops them quietly, because a comment that does not match leaves no log row to notice.

## The fix

`foldDiacritics` normalizes to NFD, drops combining marks, recomposes. Applied to **both sides** inside `matchKeywords`, so it is symmetric.

The fold is scoped to Latin-script bases, and that scoping is the substance of this PR rather than caution for its own sake. The usual one-liner:

```ts
text.normalize("NFD").replace(/\p{M}/gu, "")
```

is wrong for a tool that has already gone to the trouble of supporting non-Latin scripts, because a combining mark is load bearing outside Latin. Measured, that one-liner does this:

| input | naive fold | what broke |
|---|---|---|
| `किताब` | `कतब` | Devanagari vowel signs deleted |
| `สวัสดี` | `สวสด` | Thai vowel marks deleted |
| `مَرْحَبًا` | `مرحبا` | Arabic harakat deleted |
| `йод` | `иод` | different Cyrillic word |
| `Україна` | `Украіна` | Ukrainian ї folded to і |
| `ガード` | `カート` | dakuten flipped: "guard" becomes "cart" |

Walking the decomposed string and dropping a mark only when the base character before it is `\p{Script=Latin}` leaves every one of those byte for byte identical. The tests assert that directly, including the Japanese case.

Input is decomposed before the walk so precomposed (`U+00E9`) and decomposed (`U+0065 U+0301`) sources behave the same. The Instagram API returns both.

## What does not change

- Whole-word boundaries still hold after folding: `apreço` does not match a `preco` keyword in whole-word mode.
- Non-Latin keywords match exactly as before, and `иод` still does not match `йод`.
- `matchedKeyword` is still returned exactly as the campaign spelled it, not the folded form, so the DM log and the UI are unaffected.
- `stripSpecialCharacters` keeps its existing contract and its existing tests. The fold is a separate exported function.

## Out of scope on purpose

Ligature folding. `Fußball` does not match `fussball`, because ß is a letter rather than a diacritic and folding it needs a locale-aware mapping rather than NFD. Happy to do it in a follow-up if you want it.

## Checks

All four from `CONTRIBUTING.md` pass locally:

- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` 14 files, 158 tests passing (13 added here)
- `npm run build` succeeds

`__tests__/follower-history.test.ts` needs `npm run db:generate` before it will load, on `main` as well as on this branch. Worth a line in `CONTRIBUTING.md` if you agree.

## Why I was in here

I was reading OpenReply closely while planning comment-to-DM automation for a product that ships pt-BR and es-LA as first-class locales, which is how this surfaced. Thanks for open-sourcing it, the Unicode note already in the matcher header is what made the gap easy to spot.