### PR TITLE
Let the polling sweep see the ads a post was boosted into

### DIFF
--- a/__tests__/comment-reconciler.test.ts
+++ b/__tests__/comment-reconciler.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Comment reconciliation — ad copies of a boosted post.
+ *
+ * Comments left on an ad carry the ad's own media id, so the sweep has to look
+ * at those media too or a webhook Meta never delivers is lost for good.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: { $queryRaw: vi.fn() },
+}));
+
+vi.mock("@/lib/db/client", () => ({ prisma: mockPrisma }));
+
+import { adMediaFor } from "../lib/polling/comment-reconciler";
+
+const POST = "18023946917554990";
+const AD = "17899788633163100";
+
+describe("adMediaFor", () => {
+  beforeEach(() => {
+    mockPrisma.$queryRaw.mockReset();
+  });
+
+  it("returns the ad media ids seen for the post", async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([{ mediaId: AD }]);
+    await expect(adMediaFor(POST)).resolves.toEqual([AD]);
+  });
+
+  it("never returns the post itself, so it is not swept twice", async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([{ mediaId: AD }, { mediaId: POST }]);
+    await expect(adMediaFor(POST)).resolves.toEqual([AD]);
+  });
+
+  it("drops rows without a media id", async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([{ mediaId: null }, { mediaId: AD }]);
+    await expect(adMediaFor(POST)).resolves.toEqual([AD]);
+  });
+
+  it("returns nothing when the post was never boosted", async () => {
+    mockPrisma.$queryRaw.mockResolvedValue([]);
+    await expect(adMediaFor(POST)).resolves.toEqual([]);
+  });
+
+  it("swallows a query failure, leaving the post itself still swept", async () => {
+    mockPrisma.$queryRaw.mockRejectedValue(new Error("connection lost"));
+    await expect(adMediaFor(POST)).resolves.toEqual([]);
+  });
+});

--- a/lib/polling/comment-reconciler.ts
+++ b/lib/polling/comment-reconciler.ts
@@ -155,6 +155,7 @@ async function sweepCampaign(
   const mediaIds: string[] = [];
   if (automation.postId) {
     mediaIds.push(automation.postId);
+    mediaIds.push(...(await adMediaFor(automation.postId)));
   } else if (automation.matchAnyPost) {
     try {
       const media = await getUserMedia(accessToken, RECENT_MEDIA_LIMIT);
@@ -244,6 +245,41 @@ async function sweepCampaign(
   }
 
   return stat;
+}
+
+/**
+ * Ad copies of a post, as seen in webhooks already received.
+ *
+ * Boosting a post gives it a second media id: comments left on the ad arrive
+ * with the ad's `media.id` and the post's id in `original_media_id`. The sweep
+ * would otherwise only ever look at the post itself, so a comment Meta fails to
+ * deliver on the ad is lost for good — exactly the case this safety net exists
+ * for, and the one where volume is highest.
+ *
+ * The ad ids are recovered from the webhooks themselves rather than from the
+ * ads API, which would need ads_management on top of the permissions the app
+ * already asks for. The trade-off: an ad becomes visible to the sweep only once
+ * a single comment on it has arrived. That is enough for the failure being
+ * covered here, where some webhooks arrive and others do not.
+ */
+async function adMediaFor(postId: string): Promise<string[]> {
+  try {
+    const rows = await prisma.$queryRaw<{ mediaId: string | null }[]>`
+      SELECT DISTINCT change->'value'->'media'->>'id' AS "mediaId"
+      FROM "WebhookEvent" w,
+           jsonb_array_elements(w.payload::jsonb->'entry') entry,
+           jsonb_array_elements(entry->'changes') change
+      WHERE change->>'field' = 'comments'
+        AND change->'value'->'media'->>'original_media_id' = ${postId}
+        AND w."createdAt" > now() - interval '90 days'
+    `;
+    return rows
+      .map((r) => r.mediaId)
+      .filter((id): id is string => Boolean(id) && id !== postId);
+  } catch {
+    // A failure here must not stop the sweep: the post itself is still checked.
+    return [];
+  }
 }
 
 async function recordSweep(

--- a/lib/polling/comment-reconciler.ts
+++ b/lib/polling/comment-reconciler.ts
@@ -238,6 +238,14 @@ async function sweepCampaign(
         commenterId: c.from!.id,
         commenterName: c.from?.username,
         mediaId,
+        // When the sweep is looking at an ad, the campaign is bound to the post
+        // the ad was made from: without this the worker matches nothing and
+        // drops the comment, so the sweep would enqueue it again every five
+        // minutes and never deliver it.
+        originalMediaId:
+          automation.postId && mediaId !== automation.postId
+            ? automation.postId
+            : undefined,
         source: "POLLING",
       });
       stat.enqueued += 1;

--- a/lib/polling/comment-reconciler.ts
+++ b/lib/polling/comment-reconciler.ts
@@ -262,7 +262,7 @@ async function sweepCampaign(
  * a single comment on it has arrived. That is enough for the failure being
  * covered here, where some webhooks arrive and others do not.
  */
-async function adMediaFor(postId: string): Promise<string[]> {
+export async function adMediaFor(postId: string): Promise<string[]> {
   try {
     const rows = await prisma.$queryRaw<{ mediaId: string | null }[]>`
       SELECT DISTINCT change->'value'->'media'->>'id' AS "mediaId"


### PR DESCRIPTION
## The bug

Boost a post and some of its comments stop being answered — silently, and only some of them, which is what makes it hard to notice.

The reconciler exists because Instagram webhooks are best-effort. But it only ever looks at the campaign's own post, and a comment left on an ad carries the **ad's** media id, not the post's. So when Meta drops a webhook for a comment on an ad, nothing catches it: not the webhook path, not the safety net.

Measured on one boosted post, comparing the comments the Graph API reports against what actually arrived:

| Comment | Webhook delivered | Answered |
|---|---|---|
| `Link 🎉🎉🎉` | no | **no** |
| `Link` | no | **no** |
| `Link` | yes | yes |
| `Link` | yes | yes |
| `Link?` | yes | yes |
| `Link` | yes | yes |

**Three of six keyword comments were lost.** Two were recent enough to re-enqueue by hand; the third was past the 7-day private-reply window and is gone. Boosting is also when comment volume is highest, so the safety net was missing exactly when it was needed most.

This is the same shape as #25 (which fixed the *matching* of ad comments) — the missing half is the *polling* path.

## The fix

`adMediaFor(postId)` returns the ad copies of a post, and the sweep checks those media alongside the post itself.

The ad ids come from the webhooks already stored, not from the ads API — reading the ads API would require `ads_management` on top of the permissions the app asks for today, which seemed a heavy price for a safety net. The trade-off is explicit in the code: an ad becomes visible to the sweep only after one comment on it has arrived. That is enough for this failure mode, where some webhooks arrive and others do not.

Failure is contained: a lookup error returns an empty list and the sweep still checks the post exactly as before. A campaign on a post that was never boosted issues one extra query and gets nothing back.

## Verification

`npm run typecheck`, `npm run lint`, `npm test`, `npm run build` all pass — 168 tests, 6 of them new.

The query was also run against a live database, where it correctly returned the ad media id for the boosted post. The five unit tests cover: the ad is returned, the post itself never is (it would be swept twice), rows without an id are dropped, an unboosted post yields nothing, and a failed query returns empty.