### PR TITLE
docs: clarify current comment dedup behavior

### DIFF
--- a/lib/queue/client.ts
+++ b/lib/queue/client.ts
@@ -33,8 +33,8 @@ export interface ProcessCommentJob {
   // from. Campaigns are bound to that post, so both ids have to be matched.
   originalMediaId?: string;
   requeueAttempt?: number;
-  // Which path enqueued this comment. Recorded in the shared ProcessedComment
-  // dedup store so the reconciler can tell webhook- from polling-caught comments.
+  // Which path enqueued this comment. It is not copied to ProcessedComment or
+  // used for reconciliation dedup.
   source?: CommentSource;
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -253,12 +253,9 @@ model DmLog {
   @@index([status])
 }
 
-// Every comment the system has seen, from either the webhook or the polling
-// reconciler. This is the shared dedup set: a comment id present here has
-// already been queued for processing, so neither path acts on it twice. It is
-// distinct from DmLog (which only records comments that matched a campaign);
-// this records all comments so the reconciler doesn't re-sweep non-matching
-// ones every cycle.
+// Legacy reconciliation model; currently unwired. Runtime code does not read
+// or write ProcessedComment. Current reconciliation dedup uses owner-reply
+// checks and DmLog guards instead.
 model ProcessedComment {
   id                 String   @id @default(cuid())
   instagramAccountId String


### PR DESCRIPTION
## Summary

- correct the queue job comment so it no longer claims `source` is persisted in `ProcessedComment`
- document that `ProcessedComment` is currently unwired and that reconciliation relies on owner-reply checks and `DmLog` guards
- leave runtime behavior, schema fields, and migrations unchanged

## Verification

- `npm run db:generate`
- `npx prisma validate`
- `npm run typecheck`
- `npm run lint`
- `npm test` (184 tests)
- `git diff --check upstream/main...HEAD`

Closes #38