### PR TITLE
fix(campaigns): copy every setting when duplicating a campaign

### DIFF
--- a/__tests__/campaign-duplicate.test.ts
+++ b/__tests__/campaign-duplicate.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPrisma } = vi.hoisted(() => ({
+  mockPrisma: {
+    automation: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/db/client", () => ({
+  prisma: mockPrisma,
+}));
+
+import { buildDuplicateName, duplicateCampaign } from "../lib/campaigns/duplicate";
+
+// A campaign with every option turned on, shaped like the stored row.
+const sourceCampaign = {
+  id: "automation_123",
+  workspaceId: "workspace_123",
+  instagramAccountId: "account_123",
+  name: "Product Link Drop",
+  goal: "Product link request",
+  postId: "post_123",
+  postUrl: "https://instagram.com/p/example",
+  pendingNextReel: false,
+  matchAnyPost: false,
+  keywords: ["LINK", "SHOP"],
+  matchAnyWord: false,
+  dmTriggerEnabled: true,
+  dmMessage: "Here is the link {username}",
+  openingDmEnabled: true,
+  openingDmMessage: "Tap below for the link",
+  openingDmButtonLabel: "Send it",
+  linkButtonLabel: "Get offer",
+  requireFollow: true,
+  followPromptMessage: "Follow first, then tap below",
+  followPromptButtonLabel: "i'm following",
+  followUpEnabled: true,
+  followUpMessage: "Thanks for grabbing it!",
+  followUpDelayMinutes: 30,
+  publicReplyEnabled: true,
+  publicReplyMessage: "Sent!",
+  publicReplyMessages: ["Sent!", "Check your DMs"],
+  isActive: true,
+  wholeWordMatch: true,
+  reportShareSlug: "report_123",
+  reportShareEnabled: false,
+  createdAt: new Date("2026-05-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-05-20T00:00:00.000Z"),
+  trackedLinks: [
+    {
+      id: "link_1",
+      slug: "tracked_1",
+      label: "Primary campaign link",
+      destinationUrl: "https://example.com/product",
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    },
+    {
+      id: "link_2",
+      slug: "tracked_2",
+      label: "Read the guide",
+      destinationUrl: "https://example.com/guide",
+      createdAt: new Date("2026-05-02T00:00:00.000Z"),
+    },
+  ],
+};
+
+// Fields of the original that describe which row it is, not how it behaves.
+// Everything else has to reach the copy.
+const NOT_COPIED = new Set([
+  "id",
+  "name",
+  "isActive",
+  "reportShareSlug",
+  "createdAt",
+  "updatedAt",
+  "trackedLinks",
+]);
+
+function createArgs() {
+  return mockPrisma.automation.create.mock.calls[0][0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockPrisma.automation.findFirst.mockResolvedValue(sourceCampaign);
+  mockPrisma.automation.create.mockImplementation(
+    async ({ data }: { data: Record<string, unknown> }) => ({
+      id: "automation_copy",
+      ...data,
+    })
+  );
+});
+
+describe("duplicateCampaign", () => {
+  it("copies the settings the old client-side payload dropped", async () => {
+    await duplicateCampaign({
+      automationId: "automation_123",
+      workspaceId: "workspace_123",
+    });
+
+    expect(createArgs().data).toMatchObject({
+      // "Also reply when someone DMs these words".
+      dmTriggerEnabled: true,
+      // The follow-up thank-you message.
+      followUpEnabled: true,
+      followUpMessage: "Thanks for grabbing it!",
+      followUpDelayMinutes: 30,
+      // The primary link button title.
+      linkButtonLabel: "Get offer",
+      goal: "Product link request",
+      reportShareEnabled: false,
+    });
+  });
+
+  it("copies every setting on the source row", async () => {
+    await duplicateCampaign({
+      automationId: "automation_123",
+      workspaceId: "workspace_123",
+    });
+
+    const { data } = createArgs();
+    for (const [field, value] of Object.entries(sourceCampaign)) {
+      if (NOT_COPIED.has(field)) continue;
+      expect({ [field]: data[field] }).toEqual({ [field]: value });
+    }
+  });
+
+  it("starts the copy paused and renames it", async () => {
+    const copy = await duplicateCampaign({
+      automationId: "automation_123",
+      workspaceId: "workspace_123",
+    });
+
+    expect(copy).toMatchObject({
+      isActive: false,
+      name: "Product Link Drop copy",
+    });
+    // The copy is a new row, so the id and timestamps are left to the database.
+    expect(createArgs().data.id).toBeUndefined();
+    expect(createArgs().data.createdAt).toBeUndefined();
+  });
+
+  it("keeps the copied name within the 100 character limit", () => {
+    const longName = "a".repeat(100);
+    const duplicated = buildDuplicateName(longName);
+
+    expect(duplicated.length).toBeLessThanOrEqual(100);
+    expect(duplicated.endsWith(" copy")).toBe(true);
+  });
+
+  it("gives the copy its own report link", async () => {
+    await duplicateCampaign({
+      automationId: "automation_123",
+      workspaceId: "workspace_123",
+    });
+
+    expect(createArgs().data.reportShareSlug).toEqual(expect.any(String));
+    expect(createArgs().data.reportShareSlug).not.toBe(
+      sourceCampaign.reportShareSlug
+    );
+  });
+
+  it("recreates every tracked link with a fresh slug and its own label", async () => {
+    await duplicateCampaign({
+      automationId: "automation_123",
+      workspaceId: "workspace_123",
+    });
+
+    const created = createArgs().data.trackedLinks.create;
+    expect(created).toHaveLength(2);
+    expect(created[0]).toMatchObject({
+      workspaceId: "workspace_123",
+      label: "Primary campaign link",
+      destinationUrl: "https://example.com/product",
+    });
+    expect(created[1]).toMatchObject({
+      label: "Read the guide",
+      destinationUrl: "https://example.com/guide",
+    });
+
+    const slugs = created.map((link: { slug: string }) => link.slug);
+    expect(slugs).not.toContain("tracked_1");
+    expect(slugs).not.toContain("tracked_2");
+    expect(new Set(slugs).size).toBe(2);
+  });
+
+  it("does not copy a campaign from another workspace", async () => {
+    mockPrisma.automation.findFirst.mockResolvedValue(null);
+
+    const copy = await duplicateCampaign({
+      automationId: "automation_123",
+      workspaceId: "workspace_other",
+    });
+
+    expect(copy).toBeNull();
+    expect(mockPrisma.automation.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "automation_123", workspaceId: "workspace_other" },
+      })
+    );
+    expect(mockPrisma.automation.create).not.toHaveBeenCalled();
+  });
+});

--- a/app/(dashboard)/campaigns/page.tsx
+++ b/app/(dashboard)/campaigns/page.tsx
@@ -237,37 +237,14 @@ export default function CampaignsPage() {
     }
   }
 
-  async function duplicateAutomation(auto: Campaign) {
+  // The copy is made server-side from the stored campaign, so settings this
+  // list never loads (the DM trigger, the follow-up, the link button label)
+  // still come along.
+  async function duplicateAutomation(id: string) {
     setMenuOpenId(null);
-    const specific = !auto.matchAnyPost && !auto.pendingNextReel;
     try {
-      const res = await fetch("/api/automations", {
+      const res = await fetch(`/api/automations/duplicate?id=${id}`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: `${auto.name} copy`,
-          instagramAccountId: auto.instagramAccountId,
-          postId: specific ? auto.postId : null,
-          postUrl: specific ? auto.postUrl : null,
-          matchAnyPost: auto.matchAnyPost,
-          pendingNextReel: auto.pendingNextReel,
-          matchAnyWord: auto.matchAnyWord,
-          keywords: auto.keywords,
-          dmMessage: auto.dmMessage,
-          openingDmEnabled: auto.openingDmEnabled,
-          openingDmMessage: auto.openingDmMessage,
-          openingDmButtonLabel: auto.openingDmButtonLabel,
-          publicReplyEnabled: auto.publicReplyEnabled,
-          publicReplyMessages: auto.publicReplyMessages,
-          trackedDestinationUrl: auto.trackedLinks[0]?.destinationUrl ?? "",
-          secondaryDestinationUrl: auto.trackedLinks[1]?.destinationUrl ?? "",
-          secondaryButtonLabel: auto.trackedLinks[1]?.label ?? "Open link",
-          requireFollow: auto.requireFollow,
-          followPromptMessage: auto.followPromptMessage,
-          followPromptButtonLabel: auto.followPromptButtonLabel,
-          wholeWordMatch: auto.wholeWordMatch,
-          isActive: false,
-        }),
       });
       const data = await res.json();
       if (data.success) void fetchAutomations();
@@ -576,7 +553,7 @@ export default function CampaignsPage() {
                       />
                       <div className="absolute right-0 z-20 mt-1 w-36 overflow-hidden rounded-lg border border-border bg-surface shadow-lg">
                         <button
-                          onClick={() => void duplicateAutomation(auto)}
+                          onClick={() => void duplicateAutomation(auto.id)}
                           className="block w-full px-3 py-2 text-left text-sm text-foreground hover:bg-surface-hover"
                         >
                           Duplicate

--- a/app/api/automations/duplicate/route.ts
+++ b/app/api/automations/duplicate/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { duplicateCampaign } from "@/lib/campaigns/duplicate";
+import {
+  canManageWorkspace,
+  getCurrentWorkspaceContext,
+} from "@/lib/workspace-access";
+
+export async function POST(request: NextRequest) {
+  const context = await getCurrentWorkspaceContext();
+  if (!context) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  if (!canManageWorkspace(context.role)) {
+    return NextResponse.json(
+      { success: false, error: "Only owners and admins can create campaigns" },
+      { status: 403 }
+    );
+  }
+
+  const automationId = request.nextUrl.searchParams.get("id");
+  if (!automationId) {
+    return NextResponse.json(
+      { success: false, error: "Missing campaign ID" },
+      { status: 400 }
+    );
+  }
+
+  const duplicate = await duplicateCampaign({
+    automationId,
+    workspaceId: context.workspaceId,
+  });
+
+  if (!duplicate) {
+    return NextResponse.json(
+      { success: false, error: "Campaign not found" },
+      { status: 404 }
+    );
+  }
+
+  return NextResponse.json(
+    { success: true, data: duplicate },
+    { status: 201 }
+  );
+}

--- a/lib/campaigns/duplicate.ts
+++ b/lib/campaigns/duplicate.ts
@@ -1,0 +1,78 @@
+import { prisma } from "@/lib/db/client";
+import { generateReportShareSlug } from "@/lib/reports/share";
+import { generateTrackedLinkSlug } from "@/lib/tracking/server";
+
+// Matches the campaign name limit the create and update schemas enforce.
+const MAX_NAME_LENGTH = 100;
+const COPY_SUFFIX = " copy";
+
+/**
+ * Name for a duplicated campaign. The suffix always survives, so a name that
+ * already fills the 100 character limit is trimmed to make room for it instead
+ * of producing a name the API would reject.
+ */
+export function buildDuplicateName(name: string): string {
+  const suffixed = `${name}${COPY_SUFFIX}`;
+  if (suffixed.length <= MAX_NAME_LENGTH) return suffixed;
+
+  const trimmed = name.slice(0, MAX_NAME_LENGTH - COPY_SUFFIX.length).trimEnd();
+  return `${trimmed}${COPY_SUFFIX}`;
+}
+
+/**
+ * Copy a campaign inside its workspace. Returns null when the campaign does
+ * not exist in that workspace.
+ *
+ * The copy is built from the stored row, not from a payload the browser
+ * assembles, so every setting comes along, including the ones the campaigns
+ * list never loads, and a field added to the model later is copied without
+ * anyone having to remember this function.
+ *
+ * Four things are deliberately not carried over: the copy starts paused so it
+ * cannot fire before it has been reviewed, it gets its own report share slug,
+ * its tracked links get fresh slugs so click stats stay separate from the
+ * original's, and the name gains a "copy" suffix.
+ */
+export async function duplicateCampaign({
+  automationId,
+  workspaceId,
+}: {
+  automationId: string;
+  workspaceId: string;
+}) {
+  const source = await prisma.automation.findFirst({
+    where: { id: automationId, workspaceId },
+    include: { trackedLinks: { orderBy: { createdAt: "asc" } } },
+  });
+
+  if (!source) return null;
+
+  // Every setting on the row carries over. The links are recreated rather than
+  // spread, since they are rows of their own.
+  const { trackedLinks, ...settings } = source;
+
+  return prisma.automation.create({
+    data: {
+      ...settings,
+      // The rest of the row identifies the original rather than describing it,
+      // so the copy is given its own. Passing `undefined` to Prisma leaves a
+      // field out of the insert, which is what hands back the column default:
+      // a new id, and timestamps of now.
+      id: undefined,
+      createdAt: undefined,
+      updatedAt: undefined,
+      name: buildDuplicateName(settings.name),
+      isActive: false,
+      reportShareSlug: generateReportShareSlug(),
+      trackedLinks: {
+        create: trackedLinks.map((link) => ({
+          workspaceId: source.workspaceId,
+          slug: generateTrackedLinkSlug(),
+          label: link.label,
+          destinationUrl: link.destinationUrl,
+        })),
+      },
+    },
+    include: { trackedLinks: true },
+  });
+}


### PR DESCRIPTION
## The bug

Duplicating a campaign silently drops several settings. The copy loses:

- **"Also reply when someone DMs these words"** (`dmTriggerEnabled`)
- **The follow-up thank-you message**, and its delay (`followUpEnabled`, `followUpMessage`, `followUpDelayMinutes`)
- **The primary link button label** (`linkButtonLabel`), so a button that said "Get offer" comes back as "Open link"
- **The campaign goal** (`goal`), which shows on the shared report

## Why

`duplicateAutomation` in `app/(dashboard)/campaigns/page.tsx` rebuilt a create payload by hand from the campaign object the list page holds. The `Campaign` interface on that page never declared those four fields, so they were not in the object, not in the payload, and nothing typed or tested flagged it. Any setting added to the model after the duplicate payload was written is dropped the same way.

## The fix

Copy on the server, from the stored row.

New `POST /api/automations/duplicate?id=<id>` loads the campaign in the caller's workspace and spreads it into the new one, so every column comes along and a column added later is copied without anyone having to remember this code path. Only the identifying parts are replaced:

- a new id and timestamps
- a fresh report share slug
- fresh tracked link slugs, so the copy's click stats stay separate from the original's
- the copy still starts paused, as before

The client call is now one line, and the browser no longer needs to know the shape of a campaign to copy one.

## Two smaller fixes in the same path

- **Tracked links keep their labels, and all of them are copied.** The old payload re-sent `trackedLinks[0]` and `trackedLinks[1]` as URLs and rebuilt the labels from defaults. The worker supports up to 3 buttons, so a third link was dropped.
- **A long name no longer breaks duplication.** `${name} copy` could exceed the 100 character limit the create schema enforces, and the 400 only reached `console.error`, so the click appeared to do nothing. The suffix now trims the name to fit.

## Tests

`__tests__/campaign-duplicate.test.ts`, following the existing prisma-mock pattern: the previously dropped settings are asserted by name, plus a loop asserting every field on the source row reaches the copy except the ones that identify the original, the paused state and rename, the fresh report and link slugs, and workspace scoping.

```
npm run typecheck   pass
npm run lint        pass
npm test            pass (17 files, 191 tests)
npm run build       pass
```

Not run: the Meta side. Nothing here touches sending, and a duplicate is created paused either way.
