### PR TITLE
fix(rate-limiter): release the reserved DM slot when a send fails

### DIFF
--- a/__tests__/dm-worker.test.ts
+++ b/__tests__/dm-worker.test.ts
@@ -12,6 +12,7 @@ const {
   mockDecryptToken,
   mockMatchKeywords,
   mockReserveDMSlot,
+  mockReleaseDMSlot,
   mockQueueAdd,
   mockReserveWorkspaceDMSend,
   mockReleaseWorkspaceDMReservation,
@@ -47,6 +48,7 @@ const {
   mockDecryptToken: vi.fn(),
   mockMatchKeywords: vi.fn(),
   mockReserveDMSlot: vi.fn(),
+  mockReleaseDMSlot: vi.fn(),
   mockQueueAdd: vi.fn(),
   mockReserveWorkspaceDMSend: vi.fn(),
   mockReleaseWorkspaceDMReservation: vi.fn(),
@@ -96,6 +98,7 @@ vi.mock("@/lib/utils/keyword-matcher", () => ({
 
 vi.mock("@/lib/utils/rate-limiter", () => ({
   reserveDMSlot: mockReserveDMSlot,
+  releaseDMSlot: mockReleaseDMSlot,
 }));
 
 vi.mock("@/lib/billing/usage", () => ({
@@ -254,6 +257,7 @@ beforeEach(() => {
     shouldSkip: false,
     reserved: true,
   });
+  mockReleaseDMSlot.mockResolvedValue(0);
   mockReleaseWorkspaceDMReservation.mockResolvedValue({ count: 1 });
   mockSendPrivateReply.mockResolvedValue({
     recipient_id: "commenter_999",
@@ -345,6 +349,8 @@ describe("DM Worker — Full Pipeline", () => {
     );
     expect(mockReserveWorkspaceDMSend).toHaveBeenCalledWith("workspace_123");
     expect(mockReserveDMSlot).toHaveBeenCalledWith("ig_456", 0);
+    // A successful send keeps its slot; the release path is failure-only.
+    expect(mockReleaseDMSlot).not.toHaveBeenCalled();
     expect(mockDecryptToken).toHaveBeenCalledWith("encrypted_token_abc");
     expect(mockSendPrivateReply).toHaveBeenCalledWith(
       "decrypted_token",
@@ -900,6 +906,10 @@ describe("DM Worker — one private reply per comment", () => {
     await expect(processor(createMockJob())).rejects.toThrow(
       "The comment is invalid for a private reply"
     );
+
+    // The reserved rate slot must be handed back when the send fails, so a
+    // comment that never delivered a DM does not burn slots on each retry.
+    expect(mockReleaseDMSlot).toHaveBeenCalledWith("ig_456");
 
     // A text retry on the same comment would fail identically and overwrite the
     // real reason, so it must not be attempted.

--- a/__tests__/rate-limiter.test.ts
+++ b/__tests__/rate-limiter.test.ts
@@ -7,10 +7,11 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockGet, mockEval, mockDel } = vi.hoisted(() => ({
+const { mockGet, mockEval, mockDel, mockDecr } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockEval: vi.fn(),
   mockDel: vi.fn(),
+  mockDecr: vi.fn(),
 }));
 
 vi.mock("ioredis", () => {
@@ -20,6 +21,7 @@ vi.mock("ioredis", () => {
     this.get = mockGet;
     this.eval = mockEval;
     this.del = mockDel;
+    this.decr = mockDecr;
     return this;
   });
   return { default: MockRedis };
@@ -31,6 +33,7 @@ import {
   checkRateLimit,
   incrementDMCounter,
   reserveDMSlot,
+  releaseDMSlot,
   RATE_LIMIT_MAX,
 } from "../lib/utils/rate-limiter";
 
@@ -132,5 +135,25 @@ describe("incrementDMCounter", () => {
 
     expect(mockEval).toHaveBeenCalled();
     expect(count).toBe(51);
+  });
+});
+
+describe("releaseDMSlot", () => {
+  it("hands a reserved slot back and returns the new count", async () => {
+    mockDecr.mockResolvedValue(49);
+
+    const count = await releaseDMSlot("account_123");
+
+    expect(mockDecr).toHaveBeenCalledWith("rate:dm:account_123");
+    expect(count).toBe(49);
+  });
+
+  it("clamps to zero and clears the key when nothing was reserved", async () => {
+    mockDecr.mockResolvedValue(-1);
+
+    const count = await releaseDMSlot("account_123");
+
+    expect(count).toBe(0);
+    expect(mockDel).toHaveBeenCalledWith("rate:dm:account_123");
   });
 });

--- a/lib/queue/dm-worker.ts
+++ b/lib/queue/dm-worker.ts
@@ -32,7 +32,7 @@ import {
   type InstagramContext,
 } from "@/lib/instagram/provider";
 import { matchKeywords } from "@/lib/utils/keyword-matcher";
-import { reserveDMSlot } from "@/lib/utils/rate-limiter";
+import { reserveDMSlot, releaseDMSlot } from "@/lib/utils/rate-limiter";
 import {
   releaseWorkspaceDMReservation,
   reserveWorkspaceDMSend,
@@ -714,6 +714,12 @@ async function processComment(job: Job<ProcessCommentJob>): Promise<void> {
         },
       });
     } catch (error) {
+      // The rate slot was reserved before the send; this send did not deliver a
+      // DM, so hand the slot back instead of burning it (and burning more on
+      // each BullMQ retry) until the hourly TTL expires.
+      if (rateLimit?.reserved) {
+        await releaseDMSlot(instagramAccountId);
+      }
       await releaseWorkspaceDMReservation(
         automation.workspaceId,
         usage.periodStart

--- a/lib/utils/rate-limiter.ts
+++ b/lib/utils/rate-limiter.ts
@@ -189,6 +189,34 @@ export async function reserveDMSlot(
 }
 
 /**
+ * Release a DM slot previously taken by reserveDMSlot.
+ *
+ * reserveDMSlot increments the hourly counter before the send, so concurrent
+ * jobs can't all pass the check at once. When that send then fails (closed
+ * messaging window, expired token, rejected reply) the reserved slot is never
+ * used and must be handed back. Otherwise a comment that never delivers a DM
+ * still burns one slot per attempt, and BullMQ's retries burn several. On a
+ * post with many failing sends the counter inflates past the real number of
+ * DMs and legitimate replies get skipped as rate-limited until the TTL expires.
+ *
+ * DECR is atomic and preserves the key's TTL, so the hourly window still resets
+ * when it originally would. A missing key (the window already rolled over)
+ * would decrement to -1 with no expiry, so that case is clamped back to zero.
+ */
+export async function releaseDMSlot(
+  instagramAccountId: string
+): Promise<number> {
+  const client = getRedis();
+  const key = `rate:dm:${instagramAccountId}`;
+  const next = await client.decr(key);
+  if (next < 0) {
+    await client.del(key);
+    return 0;
+  }
+  return next;
+}
+
+/**
  * Backwards-compatible helper for tests and admin scripts.
  * Prefer reserveDMSlot in workers.
  */


### PR DESCRIPTION
## The bug

`reserveDMSlot` increments the hourly private-reply counter **before** the send, so concurrent jobs can't all pass the check before any of them increments. But nothing ever gives the slot back.

When the send then fails — a closed messaging window, an expired token, a rejected reply — the reserved slot stays counted. BullMQ retries (`attempts: 3`) call `reserveDMSlot` again, so a single comment that never delivers a DM burns 3+ slots against the 750/h cap the file itself calls a "hard ceiling with no headroom". On a post with many failing sends (exactly when comment volume is highest) the counter inflates past the real number of DMs sent, and legitimate replies start coming back `SKIPPED_RATE_LIMIT`. It only recovers when the 1-hour TTL expires.

The send-failure `catch` in `dm-worker.ts` already releases the workspace/plan reservation on failure; it just never released the rate slot.

## The fix

`releaseDMSlot(instagramAccountId)` hands the slot back. `DECR` is atomic and preserves the key's TTL, so the hourly window still resets when it originally would. A missing key (the window already rolled over) would decrement to `-1` with no expiry, so that case is clamped back to zero.

It is called from the send-failure `catch`, guarded by `rateLimit?.reserved`, so it only runs when a slot was actually taken and no DM went out:

```ts
} catch (error) {
  if (rateLimit?.reserved) {
    await releaseDMSlot(instagramAccountId);
  }
  await releaseWorkspaceDMReservation(...);
  ...
}
```

## What does not change

- A successful send still counts against the cap.
- The reserve path is untouched — the pre-send atomic reservation that prevents the check-then-increment race stays exactly as it was.
- The `reserveDMSlot`-threw branch does not release, because in that case nothing was reserved.

## One edge left as-is

If a send is ambiguous (Meta actually delivered but the call surfaced an error, e.g. a timeout), the slot is released for a DM that did go out, so the hour under-counts by one. That is rarer and far less harmful than the current behaviour of dropping real DMs, so I left it; happy to gate it on a delivery-confirmed check if you'd prefer.

## Checks

All four from `CONTRIBUTING.md` pass locally:

- `npm run typecheck` clean
- `npm run lint` clean
- `npm test` — 233 passing (2 new `releaseDMSlot` unit tests; the worker's send-failure test now also asserts the slot is released, and a success test asserts it is not)
- `npm run build` succeeds

Not exercised against a live account — covered by unit tests only.
